### PR TITLE
FluxRecord supports dictionary-style access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#24](https://github.com/influxdata/influxdb-client-python/issues/24): Added possibility to write dictionary-style object
 1. [#27](https://github.com/influxdata/influxdb-client-python/issues/27): Added possibility to write bytes type of data
 1. [#30](https://github.com/influxdata/influxdb-client-python/issues/30): Added support for streaming a query response
+1. [#35](https://github.com/influxdata/influxdb-client-python/pull/35): FluxRecord supports dictionary-style access
 1. [#31](https://github.com/influxdata/influxdb-client-python/issues/31): Added support for delete metrics  
 
 ### API

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -37,22 +37,28 @@ class FluxRecord(FluxStructure):
         self.values = values
 
     def get_start(self):
-        return self.values.get("_start")
+        return self["_start"]
 
     def get_stop(self):
-        return self.values.get("_stop")
+        return self["_stop"]
 
     def get_time(self):
-        return self.values.get("_time")
+        return self["_time"]
 
     def get_value(self):
-        return self.values.get("_value")
+        return self["_value"]
 
     def get_field(self):
-        return self.values.get("_field")
+        return self["_field"]
 
     def get_measurement(self):
-        return self.values.get("_measurement")
+        return self["_measurement"]
+
+    def __getitem__(self, key):
+        return self.values.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        return self.values.__setitem__(key, value)
 
     def __str__(self):
         cls_name = type(self).__name__

--- a/tests/test_FluxObject.py
+++ b/tests/test_FluxObject.py
@@ -22,13 +22,26 @@ class FluxObjectTest(BaseTest):
                          FluxColumn(index=7, label='_measurement', data_type='string', group=True, default_value=''),
                          FluxColumn(index=8, label='location', data_type='string', group=True, default_value='')]
 
-        record1 = FluxRecord(table=0, values={'result': '_result', 'table': 0, '_start': _time, '_stop': _time,
-                                              '_time': _time, '_value': 1.0, '_field': 'water level',
-                                              '_measurement': 'h2o', 'location': 'coyote_creek'})
-        record2 = FluxRecord(table=0, values={'result': '_result', 'table': 0, '_start': _time, '_stop': _time,
-                                              '_time': _time + datetime.timedelta(days=1), '_value': 2.0,
-                                              '_field': 'water level', '_measurement': 'h2o',
-                                              'location': 'coyote_creek'})
+        record1 = FluxRecord(table=0)
+        record1["table"] = 0
+        record1["_start"] = _time
+        record1["_stop"] = _time
+        record1["_time"] = _time
+        record1["_value"] = 1.0
+        record1["_field"] = 'water level'
+        record1["_measurement"] = 'h2o'
+        record1["location"] = 'coyote_creek'
+
+        record2 = FluxRecord(table=0)
+        record2["table"] = 0
+        record2["_start"] = _time
+        record2["_stop"] = _time
+        record2["_time"] = _time + datetime.timedelta(days=1)
+        record2["_value"] = 2.0
+        record2["_field"] = 'water level'
+        record2["_measurement"] = 'h2o'
+        record2["location"] = 'coyote_creek'
+
         table.records = [record1, record2]
 
         self.assertEqual(9, table.columns.__len__())
@@ -39,9 +52,13 @@ class FluxObjectTest(BaseTest):
         self.assertEqual(_time, table.records[0].get_stop())
         self.assertEqual(_time, table.records[0].get_time())
         self.assertEqual(1.0, table.records[0].get_value())
+        self.assertEqual(1.0, table.records[0]["_value"])
         self.assertEqual('water level', table.records[0].get_field())
+        self.assertEqual('water level', table.records[0]["_field"])
         self.assertEqual('h2o', table.records[0].get_measurement())
+        self.assertEqual('h2o', table.records[0]["_measurement"])
         self.assertEqual('coyote_creek', table.records[0].values['location'])
+        self.assertEqual('coyote_creek', table.records[0]['location'])
 
         # record 2
         self.assertEqual(_time, table.records[1].get_start())
@@ -49,5 +66,8 @@ class FluxObjectTest(BaseTest):
         self.assertEqual(_time + datetime.timedelta(days=1), table.records[1].get_time())
         self.assertEqual(2.0, table.records[1].get_value())
         self.assertEqual('water level', table.records[1].get_field())
+        self.assertEqual('water level', table.records[1]["_field"])
         self.assertEqual('h2o', table.records[1].get_measurement())
+        self.assertEqual('h2o', table.records[1]["_measurement"])
         self.assertEqual('coyote_creek', table.records[1].values['location'])
+        self.assertEqual('coyote_creek', table.records[1]['location'])

--- a/tests/test_FluxObject.py
+++ b/tests/test_FluxObject.py
@@ -65,6 +65,7 @@ class FluxObjectTest(BaseTest):
         self.assertEqual(_time, table.records[1].get_stop())
         self.assertEqual(_time + datetime.timedelta(days=1), table.records[1].get_time())
         self.assertEqual(2.0, table.records[1].get_value())
+        self.assertEqual(2.0, table.records[1]["_value"])
         self.assertEqual('water level', table.records[1].get_field())
         self.assertEqual('water level', table.records[1]["_field"])
         self.assertEqual('h2o', table.records[1].get_measurement())


### PR DESCRIPTION
The `FluxRecord` supports dictionary-style access:

```python
record = FluxRecord()
record["table"] = 0
record["_start"] = _time
record["_stop"] = _time
record["_time"] = _time
record["_value"] = 1.0
record["_field"] = 'water level'
record["_measurement"] = 'h2o'
record["location"] = 'coyote_creek'

print(table.records[0]["_measurement"])
print(table.records[0]["_field"])
print(table.records[0]["_value"])
```

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)