### PR TITLE
fix: use default org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### API
 1. [#47](https://github.com/influxdata/influxdb-client-python/pull/47): Updated swagger to latest version
 
+### Bugs
+1. [#48](https://github.com/influxdata/influxdb-client-python/pull/48): InfluxDBClient default org is used by WriteAPI
+
 ## 1.2.0 [2019-12-06]
 
 ### Features

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import logging
-import threading
 from datetime import timedelta
 from enum import Enum
 from random import random
@@ -134,9 +133,9 @@ class WriteApi(AbstractClient):
             self._subject = None
             self._disposable = None
 
-    def write(self, bucket: str, org: str,
+    def write(self, bucket: str, org: str = None,
               record: Union[
-                  str, List['str'], Point, List['Point'], dict, List['dict'], bytes, List['bytes'], Observable],
+                  str, List['str'], Point, List['Point'], dict, List['dict'], bytes, List['bytes'], Observable] = None,
               write_precision: WritePrecision = DEFAULT_WRITE_PRECISION) -> None:
         """
         Writes time-series data into influxdb.
@@ -147,6 +146,9 @@ class WriteApi(AbstractClient):
         :param record: Points, line protocol, RxPY Observable to write
 
         """
+
+        if org is None:
+            org = self._influxdb_client.org
 
         if self._write_options.write_type is WriteType.batching:
             return self._write_batching(bucket, org, record, write_precision)


### PR DESCRIPTION
Closes #46

 InfluxDBClient default `org` is used by `WriteAPI`

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)