### PR TITLE
fix: Correctly close connection pool manager at exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugs
 1. [#61](https://github.com/influxdata/influxdb-client-python/issues/61): Correctly parse CSV where multiple results include multiple tables
+1. [#66](https://github.com/influxdata/influxdb-client-python/issues/66): Correctly close connection pool manager at exit
 
 ## 1.4.0 [2020-02-14]
 

--- a/influxdb_client/api_client.py
+++ b/influxdb_client/api_client.py
@@ -82,6 +82,8 @@ class ApiClient(object):
             self._pool.close()
             self._pool.join()
             self._pool = None
+        if self.rest_client and self.rest_client.pool_manager and hasattr(self.rest_client.pool_manager, 'clear'):
+            self.rest_client.pool_manager.clear()
 
     @property
     def pool(self):

--- a/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/openapi-generator/src/main/resources/python/api_client.mustache
@@ -77,6 +77,8 @@ class ApiClient(object):
             self._pool.close()
             self._pool.join()
             self._pool = None
+        if self.rest_client and self.rest_client.pool_manager and hasattr(self.rest_client.pool_manager, 'clear'):
+            self.rest_client.pool_manager.clear()
 
     @property
     def pool(self):


### PR DESCRIPTION
Closes #66 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)