### PR TITLE
fix: rest_api and write_api is able to be pickled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ sandbox
 
 # OpenAPI-generator
 /.openapi-generator*
+/tests/writer.pickle

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ celerybeat-schedule
 .venv
 env/
 venv/
+venv-*/
 ENV/
 env.bak/
 venv.bak/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugs
 1. [#61](https://github.com/influxdata/influxdb-client-python/issues/61): Correctly parse CSV where multiple results include multiple tables
 1. [#66](https://github.com/influxdata/influxdb-client-python/issues/66): Correctly close connection pool manager at exit
+1. [#69](https://github.com/influxdata/influxdb-client-python/issues/69): `InfluxDBClient` and `WriteApi` could serialized by [pickle](https://docs.python.org/3/library/pickle.html#object.__getstate__) (python3.7 or higher)
 
 ## 1.4.0 [2020-02-14]
 

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -58,6 +58,10 @@ class RESTClientObject(object):
         # maxsize is the number of requests to host that are allowed in parallel  # noqa: E501
         # Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501
 
+        self.configuration = configuration
+        self.pools_size = pools_size
+        self.maxsize = maxsize
+
         # cert_reqs
         if configuration.verify_ssl:
             cert_reqs = ssl.CERT_REQUIRED
@@ -292,6 +296,17 @@ class RESTClientObject(object):
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             body=body)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Remove Pool managaer
+        del state['pool_manager']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Init Pool manager
+        self.__init__(self.configuration, self.pools_size, self.maxsize)
 
 
 class ApiException(Exception):

--- a/openapi-generator/src/main/resources/python/rest.mustache
+++ b/openapi-generator/src/main/resources/python/rest.mustache
@@ -50,6 +50,10 @@ class RESTClientObject(object):
         # maxsize is the number of requests to host that are allowed in parallel  # noqa: E501
         # Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501
 
+        self.configuration = configuration
+        self.pools_size = pools_size
+        self.maxsize = maxsize
+
         # cert_reqs
         if configuration.verify_ssl:
             cert_reqs = ssl.CERT_REQUIRED
@@ -284,6 +288,17 @@ class RESTClientObject(object):
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             body=body)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Remove Pool managaer
+        del state['pool_manager']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Init Pool manager
+        self.__init__(self.configuration, self.pools_size, self.maxsize)
 
 
 class ApiException(Exception):

--- a/tests/test_WriteApiPickle.py
+++ b/tests/test_WriteApiPickle.py
@@ -1,0 +1,51 @@
+import pickle
+
+from influxdb_client import InfluxDBClient, WriteOptions
+from influxdb_client.client.write_api import WriteType
+from tests.base_test import current_milli_time, BaseTest
+
+
+class InfluxDBWriterToPickle:
+
+    def __init__(self):
+        self.client = InfluxDBClient(url="http://localhost:9999", token="my-token", org="my-org", debug=False)
+        self.write_api = self.client.write_api(
+            write_options=WriteOptions(write_type=WriteType.batching, batch_size=50_000, flush_interval=10_000))
+
+    def write(self, record):
+        self.write_api.write(bucket="my-bucket", record=record)
+
+    def terminate(self) -> None:
+        self.write_api.__del__()
+        self.client.__del__()
+
+
+class WriteApiPickle(BaseTest):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+
+    def test_write_line_protocol(self):
+        writer = InfluxDBWriterToPickle()
+
+        pickle_out = open("writer.pickle", "wb")
+        pickle.dump(writer, pickle_out)
+        pickle_out.close()
+
+        writer = pickle.load(open("writer.pickle", "rb"))
+
+        measurement = "h2o_feet_" + str(current_milli_time())
+        writer.write(record=f"{measurement},location=coyote_creek water_level=1.0")
+        writer.terminate()
+
+        tables = self.query_api.query(
+            f'from(bucket: "my-bucket") |> range(start: 0) |> filter(fn: (r) => r._measurement == "{measurement}")')
+
+        self.assertEqual(len(tables), 1)
+        self.assertEqual(len(tables[0].records), 1)
+        self.assertEqual(tables[0].records[0].get_measurement(), measurement)
+        self.assertEqual(tables[0].records[0].get_value(), 1.0)
+        self.assertEqual(tables[0].records[0].get_field(), "water_level")

--- a/tests/test_WriteApiPickle.py
+++ b/tests/test_WriteApiPickle.py
@@ -1,4 +1,7 @@
 import pickle
+import sys
+
+import pytest
 
 from influxdb_client import InfluxDBClient, WriteOptions
 from influxdb_client.client.write_api import WriteType
@@ -28,6 +31,7 @@ class WriteApiPickle(BaseTest):
     def tearDown(self) -> None:
         super().tearDown()
 
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
     def test_write_line_protocol(self):
         writer = InfluxDBWriterToPickle()
 


### PR DESCRIPTION
Closes #69

`InfluxDBClient` and `WriteApi` could serialized by [pickle](https://docs.python.org/3/library/pickle.html#object.__getstate__) (python3.7 or higher)

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)