### PR TITLE
fix: avoid to generate an empty write batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.7.0 [unreleased]
 
+### Bug Fixes
+1. [#85](https://github.com/influxdata/influxdb-client-python/issues/85): Fixed a possibility to generate empty write batch
+
 ## 1.6.0 [2020-04-17]
 
 ### Documentation


### PR DESCRIPTION
Related-to #80

Fixed a possibility to generate empty write batch

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)