### PR TITLE
fix: Fixed parameters in delete api #86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#85](https://github.com/influxdata/influxdb-client-python/issues/85): Fixed a possibility to generate empty write batch
+2. [#86](https://github.com/influxdata/influxdb-client-python/issues/86): BREAKING CHANGE: Fixed parameters in delete api - now delete api accepts also bucket name and org name instead of only ids
 
 ## 1.6.0 [2020-04-17]
 

--- a/influxdb_client/client/delete_api.py
+++ b/influxdb_client/client/delete_api.py
@@ -9,15 +9,15 @@ class DeleteApi(object):
         self._influxdb_client = influxdb_client
         self._service = DefaultService(influxdb_client.api_client)
 
-    def delete(self, start: datetime, stop: object, predicate: object, bucket_id: str, org_id: str) -> None:
+    def delete(self, start: datetime, stop: object, predicate: object, bucket: str, org: str) -> None:
         """
         Delete Time series data from InfluxDB.
         :param start: start time
         :param stop: stop time
         :param predicate: predicate
-        :param bucket_id: bucket id from which data will be deleted
-        :param org_id: organization id
+        :param bucket: bucket id or name from which data will be deleted
+        :param org: organization id or name
         :return:
         """
         predicate_request = DeletePredicateRequest(start=start, stop=stop, predicate=predicate)
-        return self._service.delete_post(delete_predicate_request=predicate_request, bucket_id=bucket_id, org_id=org_id)
+        return self._service.delete_post(delete_predicate_request=predicate_request, bucket=bucket, org=org)


### PR DESCRIPTION
Closes #86

BREAKING CHANGE: Fixed parameters in delete api - now delete api accepts also bucket name and org name instead of only ids.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)