### PR TITLE
Fixed link formating in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ influxdb-client-python
 
 InfluxDB 2.0 python client library.
 
-**Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+. For connecting to InfluxDB 1.7 or earlier instances, use the `influxdb-python <https://github.com/influxdata/influxdb-python>`_ client library.**
+**Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+. For connecting to InfluxDB 1.7 or earlier instances, use the** `influxdb-python <https://github.com/influxdata/influxdb-python>`_ **client library.**
 
 InfluxDB 2.0 client features
 ----------------------------


### PR DESCRIPTION
reStructuredText doesn't allow link insertion in bold text block

_Briefly describe your proposed changes:_
Edit in README to fix wrong link rendering behavior to in influxdb-python link.