### PR TITLE
fix: mapping dictionary without timestamp and tags into LineProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#92](https://github.com/influxdata/influxdb-client-python/issues/92): Optimize serializing Pandas DataFrame for writing
 
+### Bug Fixes
+1. [#105](https://github.com/influxdata/influxdb-client-python/pull/105): Fixed mapping dictionary without timestamp and tags into LineProtocol
+
 ## 1.7.0 [2020-05-15]
 
 ### Features

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -30,11 +30,13 @@ class Point(object):
     @staticmethod
     def from_dict(dictionary: dict, write_precision: WritePrecision = DEFAULT_WRITE_PRECISION):
         point = Point(dictionary['measurement'])
-        for tag_key, tag_value in dictionary['tags'].items():
-            point.tag(tag_key, tag_value)
+        if 'tags' in dictionary:
+            for tag_key, tag_value in dictionary['tags'].items():
+                point.tag(tag_key, tag_value)
         for field_key, field_value in dictionary['fields'].items():
             point.field(field_key, field_value)
-        point.time(dictionary['time'], write_precision=write_precision)
+        if 'time' in dictionary:
+            point.time(dictionary['time'], write_precision=write_precision)
         return point
 
     def __init__(self, measurement_name):


### PR DESCRIPTION
Closes #103


- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)