### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 1. [#112](https://github.com/influxdata/influxdb-client-python/pull/113): Support timestamp with different timezone in _convert_timestamp
 
 ### Bug Fixes
-1. [#115](https://github.com/influxdata/influxdb-client-python/pull/115): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
 1. [#117](https://github.com/influxdata/influxdb-client-python/pull/117): Fixed appending default tags for single Point 
+1. [#115](https://github.com/influxdata/influxdb-client-python/pull/115): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 
 
 ## 1.8.0 [2020-06-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#112](https://github.com/influxdata/influxdb-client-python/pull/113): Support timestamp with different timezone in _convert_timestamp
 
 ### Bug Fixes
+1. [#115](https://github.com/influxdata/influxdb-client-python/pull/115): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
 1. [#117](https://github.com/influxdata/influxdb-client-python/pull/117): Fixed appending default tags for single Point 
 
 ## 1.8.0 [2020-06-19]

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -12,6 +12,7 @@ from influxdb_client.domain.write_precision import WritePrecision
 
 EPOCH = UTC.localize(datetime.utcfromtimestamp(0))
 DEFAULT_WRITE_PRECISION = WritePrecision.NS
+_ESCAPE_MEASUREMENT = str.maketrans({'\\': '\\\\', ',': r'\,', ' ': r'\ ', '\n': '\\n', '\t': '\\t', '\r': '\\r'})
 _ESCAPE_KEY = str.maketrans({'\\': '\\\\', ',': r'\,', ' ': r'\ ', '=': r'\=', '\n': '\\n', '\t': '\\t', '\r': '\\r'})
 _ESCAPE_STRING = str.maketrans({'\"': r"\"", "\\": r"\\"})
 
@@ -75,7 +76,7 @@ class Point(object):
         return self
 
     def to_line_protocol(self):
-        _measurement = _escape_key(self._name)
+        _measurement = _escape_key(self._name, _ESCAPE_MEASUREMENT)
         _tags = _append_tags(self._tags)
         _fields = _append_fields(self._fields)
         if not _fields:
@@ -133,8 +134,10 @@ def _append_time(time, write_precision):
     return f" {int(_convert_timestamp(time, write_precision))}"
 
 
-def _escape_key(tag):
-    return str(tag).translate(_ESCAPE_KEY)
+def _escape_key(tag, escape_list=None):
+    if escape_list is None:
+        escape_list = _ESCAPE_KEY
+    return str(tag).translate(escape_list)
 
 
 def _escape_tag_value(value):

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -12,7 +12,7 @@ from influxdb_client.domain.write_precision import WritePrecision
 
 EPOCH = UTC.localize(datetime.utcfromtimestamp(0))
 DEFAULT_WRITE_PRECISION = WritePrecision.NS
-_ESCAPE_KEY = str.maketrans({'\\': '\\\\', ',': r'\,', ' ': r'\ ', '=': r'\=', '\n': ''})
+_ESCAPE_KEY = str.maketrans({'\\': '\\\\', ',': r'\,', ' ': r'\ ', '=': r'\=', '\n': '\\n', '\t': '\\t', '\r': '\\r'})
 _ESCAPE_STRING = str.maketrans({'\"': r"\"", "\\": r"\\"})
 
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -46,6 +46,14 @@ class PointTest(BaseTest):
 
         self.assertEqual("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i", point.to_line_protocol())
 
+    def test_EqualSignEscaping(self):
+
+        point = Point.measurement("h=2o") \
+            .tag("l=ocation", "e=urope") \
+            .field("l=evel", 2)
+
+        self.assertEqual("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", point.to_line_protocol())
+
     def test_OverrideTagField(self):
         point = Point.measurement("h2o") \
             .tag("location", "europe") \

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -36,6 +36,16 @@ class PointTest(BaseTest):
 
         self.assertEqual("h2o,location=europe level=2i", point.to_line_protocol())
 
+    def test_TagEscapingKeyAndValue(self):
+
+        point = Point.measurement("h\n2\ro\t_data") \
+            .tag("new\nline", "new\nline") \
+            .tag("carriage\rreturn", "carriage\nreturn") \
+            .tag("t\tab", "t\tab") \
+            .field("level", 2)
+
+        self.assertEqual("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i", point.to_line_protocol())
+
     def test_OverrideTagField(self):
         point = Point.measurement("h2o") \
             .tag("location", "europe") \


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

* serialization of `\n`, `\r` and `\t` to Line Protocol
* `=` is valid sign for measurement name 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)