### PR TITLE
fix: use Retry-After header value for Retryable error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [#117](https://github.com/influxdata/influxdb-client-python/pull/117): Fixed appending default tags for single Point 
 1. [#115](https://github.com/influxdata/influxdb-client-python/pull/115): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 
 1. [#118](https://github.com/influxdata/influxdb-client-python/issues/118): Fixed serialization of DataFrame with empty (NaN) values
+1. [#130](https://github.com/influxdata/influxdb-client-python/pull/130): Use `Retry-After` header value for Retryable error codes 
 
 ## 1.8.0 [2020-06-19]
 

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -185,7 +185,7 @@ class BatchingWriteTest(BaseTest):
 
     def test_retry_interval(self):
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
-        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=429)
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=429, adding_headers={'Retry-After': '5'})
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=503)
 
         self._write_client.write("my-bucket", "my-org",
@@ -199,7 +199,7 @@ class BatchingWriteTest(BaseTest):
 
         self.assertEqual(2, len(httpretty.httpretty.latest_requests))
 
-        time.sleep(3)
+        time.sleep(5)
 
         self.assertEqual(3, len(httpretty.httpretty.latest_requests))
 


### PR DESCRIPTION
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
