### PR TITLE
feat: use microseconds resolutions for data points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#112](https://github.com/influxdata/influxdb-client-python/pull/113): Support timestamp with different timezone in _convert_timestamp
 1. [#120](https://github.com/influxdata/influxdb-client-python/pull/120): ciso8601 is an optional dependency and has to be installed separably
 1. [#121](https://github.com/influxdata/influxdb-client-python/pull/121): Added query_data_frame_stream method
+1. [#132](https://github.com/influxdata/influxdb-client-python/pull/132): Use microseconds resolutions for data points
 
 ### Bug Fixes
 1. [#117](https://github.com/influxdata/influxdb-client-python/pull/117): Fixed appending default tags for single Point 

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -154,7 +154,7 @@ def _escape_string(value):
 
 def _to_nanoseconds(delta):
     """
-    Solutions come from v1 client. Thx.
+    Solution comes from v1 client. Thx.
 
     https://github.com/influxdata/influxdb-python/pull/811
     """

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -7,10 +7,9 @@ from decimal import Decimal
 from pytz import UTC, timezone
 
 from influxdb_client import Point, WritePrecision
-from tests.base_test import BaseTest
 
 
-class PointTest(BaseTest):
+class PointTest(unittest.TestCase):
 
     def test_MeasurementEscape(self):
         point = Point.measurement("h2 o").tag("location", "europe").tag("", "warn").field("level", 2)
@@ -153,6 +152,20 @@ class PointTest(BaseTest):
 
         self.assertEqual("h2o,location=europe level=2i 123", point.to_line_protocol())
 
+        point = Point.measurement("h2o") \
+            .tag("location", "europe") \
+            .field("level", 2) \
+            .time(timedelta(microseconds=876), WritePrecision.NS)
+
+        self.assertEqual("h2o,location=europe level=2i 876000", point.to_line_protocol())
+
+        point = Point.measurement("h2o") \
+            .tag("location", "europe") \
+            .field("level", 2) \
+            .time(timedelta(milliseconds=954), WritePrecision.NS)
+
+        self.assertEqual("h2o,location=europe level=2i 954000000", point.to_line_protocol())
+
     def test_DateTimeFormatting(self):
         date_time = datetime(2015, 10, 15, 8, 20, 15)
 
@@ -171,6 +184,27 @@ class PointTest(BaseTest):
             .time(date_time, WritePrecision.S)
 
         self.assertEqual("h2o,location=europe level=false 1444897215", point.to_line_protocol())
+
+        point = Point.measurement("h2o") \
+            .tag("location", "europe") \
+            .field("level", False) \
+            .time(date_time, WritePrecision.MS)
+
+        self.assertEqual("h2o,location=europe level=false 1444897215000", point.to_line_protocol())
+
+        point = Point.measurement("h2o") \
+            .tag("location", "europe") \
+            .field("level", False) \
+            .time(date_time, WritePrecision.US)
+
+        self.assertEqual("h2o,location=europe level=false 1444897215000750", point.to_line_protocol())
+
+        point = Point.measurement("h2o") \
+            .tag("location", "europe") \
+            .field("level", False) \
+            .time(date_time, WritePrecision.NS)
+
+        self.assertEqual("h2o,location=europe level=false 1444897215000750000", point.to_line_protocol())
 
         point = Point.measurement("h2o") \
             .tag("location", "europe") \


### PR DESCRIPTION
Data points uses `microseconds` from time delta to better precision.

see also https://github.com/influxdata/influxdb-python/pull/811

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
