### PR TITLE
feat: skip of verifying SSL certificate could be configured via config file or environment properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.10.0 [unreleased]
 
 ### Features
-1. [#136](https://github.com/influxdata/influxdb-client-python/pull/136): Allows users to skip of verifying SSL certificate 
+1. [#136](https://github.com/influxdata/influxdb-client-python/pull/136): Allows users to skip of verifying SSL certificate
+1. [#143](https://github.com/influxdata/influxdb-client-python/pull/143): Skip of verifying SSL certificate could be configured via config file or environment properties  
 
 ## 1.9.0 [2020-07-17]
 

--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,7 @@ The following options are supported:
 - ``org`` - default destination organization for writes and queries
 - ``token`` - the token to use for the authorization
 - ``timeout`` - socket timeout in ms (default value is 10000)
+- ``verify_ssl`` - set this to false to skip verifying SSL certificate when calling API from https server
 
 .. code-block:: python
 
@@ -181,6 +182,7 @@ The following options are supported:
     org=my-org
     token=my-token
     timeout=6000
+    verify_ssl=False
 
 Via Environment Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -192,6 +194,7 @@ Supported properties are:
 - ``INFLUXDB_V2_ORG`` - default destination organization for writes and queries
 - ``INFLUXDB_V2_TOKEN`` - the token to use for the authorization
 - ``INFLUXDB_V2_TIMEOUT`` - socket timeout in ms (default value is 10000)
+- ``INFLUXDB_V2_VERIFY_SSL`` - set this to false to skip verifying SSL certificate when calling API from https server
 
 .. code-block:: python
 

--- a/tests/config-disabled-ssl.ini
+++ b/tests/config-disabled-ssl.ini
@@ -1,0 +1,11 @@
+[influx2]
+url=http://localhost:9999
+org=my-org
+token=my-token
+timeout=6000
+verify_ssl=False
+
+[tags]
+id = 132-987-655
+customer = California Miner
+data_center = ${env.data_center}


### PR DESCRIPTION
Closes #142 

## Proposed Changes

The `verify_ssl` could be configured via config file or environment properties.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
