### PR TITLE
feat: WriteApi supports Iterable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.11.0 [unreleased]
 
+### Features
+1. [#152](https://github.com/influxdata/influxdb-client-python/pull/152): WriteApi supports generic Iterable type
+
 ### API
- 1. [#151](https://github.com/influxdata/influxdb-client-python/pull/151): Default port changed from 9999 -> 8086
+1. [#151](https://github.com/influxdata/influxdb-client-python/pull/151): Default port changed from 9999 -> 8086
 
 ## 1.10.0 [2020-08-14]
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from enum import Enum
 from random import random
 from time import sleep
-from typing import Union, List, Any
+from typing import Union, Any, Iterable
 
 import rx
 from rx import operators as ops, Observable
@@ -212,7 +212,7 @@ class WriteApi:
 
     def write(self, bucket: str, org: str = None,
               record: Union[
-                  str, List['str'], Point, List['Point'], dict, List['dict'], bytes, List['bytes'], Observable] = None,
+                  str, Iterable['str'], Point, Iterable['Point'], dict, Iterable['dict'], bytes, Iterable['bytes'], Observable] = None,
               write_precision: WritePrecision = DEFAULT_WRITE_PRECISION, **kwargs) -> Any:
         """
         Write time-series data into InfluxDB.
@@ -291,7 +291,7 @@ class WriteApi:
             _data = data_frame_to_list_of_points(record, self._point_settings, **kwargs)
             self._serialize(_data, write_precision, payload, **kwargs)
 
-        elif isinstance(record, list):
+        elif isinstance(record, Iterable):
             for item in record:
                 self._serialize(item, write_precision, payload, **kwargs)
 
@@ -317,7 +317,7 @@ class WriteApi:
             self._write_batching(bucket, org, data_frame_to_list_of_points(data, self._point_settings, **kwargs),
                                  precision, **kwargs)
 
-        elif isinstance(data, list):
+        elif isinstance(data, Iterable):
             for item in data:
                 self._write_batching(bucket, org, item, precision, **kwargs)
 
@@ -328,11 +328,13 @@ class WriteApi:
         return None
 
     def _append_default_tag(self, key, val, record):
-        if isinstance(record, Point):
+        if isinstance(record, bytes) or isinstance(record, str):
+            pass
+        elif isinstance(record, Point):
             record.tag(key, val)
         elif isinstance(record, dict):
             record.get("tags")[key] = val
-        elif isinstance(record, list):
+        elif isinstance(record, Iterable):
             for item in record:
                 self._append_default_tag(key, val, item)
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -212,7 +212,8 @@ class WriteApi:
 
     def write(self, bucket: str, org: str = None,
               record: Union[
-                  str, Iterable['str'], Point, Iterable['Point'], dict, Iterable['dict'], bytes, Iterable['bytes'], Observable] = None,
+                  str, Iterable['str'], Point, Iterable['Point'], dict, Iterable['dict'], bytes, Iterable['bytes'],
+                  Observable] = None,
               write_precision: WritePrecision = DEFAULT_WRITE_PRECISION, **kwargs) -> Any:
         """
         Write time-series data into InfluxDB.

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -311,11 +311,16 @@ class BatchingWriteTest(unittest.TestCase):
         _bytes2 = "h2o_feet,location=coyote_creek level\\ water_level=18.0 18".encode("utf-8")
         self._write_client.write("my-bucket", "my-org", [_bytes1, _bytes2])
 
+        # Tuple
+        _bytes3 = "h2o_feet,location=coyote_creek level\\ water_level=19.0 19".encode("utf-8")
+        _bytes4 = "h2o_feet,location=coyote_creek level\\ water_level=20.0 20".encode("utf-8")
+        self._write_client.write("my-bucket", "my-org", (_bytes3, _bytes4, ))
+
         time.sleep(1)
 
         _requests = httpretty.httpretty.latest_requests
 
-        self.assertEqual(9, len(_requests))
+        self.assertEqual(10, len(_requests))
 
         self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
                          "h2o_feet,location=coyote_creek level\\ water_level=2.0 2", _requests[0].parsed_body)
@@ -335,6 +340,8 @@ class BatchingWriteTest(unittest.TestCase):
                          "h2o_feet,location=coyote_creek level\\ water_level=16.0 16", _requests[7].parsed_body)
         self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=17.0 17\n"
                          "h2o_feet,location=coyote_creek level\\ water_level=18.0 18", _requests[8].parsed_body)
+        self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=19.0 19\n"
+                         "h2o_feet,location=coyote_creek level\\ water_level=20.0 20", _requests[9].parsed_body)
 
         pass
 


### PR DESCRIPTION
Closes #150

## Proposed Changes

- `WriteApi` supports `Iterable` type - Tuple, List, ...

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
