### PR TITLE
feat: added possibility to specify certificate file path to verify the peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#152](https://github.com/influxdata/influxdb-client-python/pull/152): WriteApi supports generic Iterable type
+1. [#158](https://github.com/influxdata/influxdb-client-python/pull/158): Added possibility to specify certificate file path to verify the peer
 
 ### API
 1. [#151](https://github.com/influxdata/influxdb-client-python/pull/151): Default port changed from 9999 -> 8086

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ The following options are supported:
 - ``token`` - the token to use for the authorization
 - ``timeout`` - socket timeout in ms (default value is 10000)
 - ``verify_ssl`` - set this to false to skip verifying SSL certificate when calling API from https server
+- ``ssl_ca_cert`` - set this to customize the certificate file to verify the peer
 
 .. code-block:: python
 
@@ -195,6 +196,7 @@ Supported properties are:
 - ``INFLUXDB_V2_TOKEN`` - the token to use for the authorization
 - ``INFLUXDB_V2_TIMEOUT`` - socket timeout in ms (default value is 10000)
 - ``INFLUXDB_V2_VERIFY_SSL`` - set this to false to skip verifying SSL certificate when calling API from https server
+- ``INFLUXDB_V2_SSL_CA_CERT`` - set this to customize the certificate file to verify the peer
 
 .. code-block:: python
 

--- a/tests/config-ssl-ca-cert.ini
+++ b/tests/config-ssl-ca-cert.ini
@@ -1,0 +1,11 @@
+[influx2]
+url=http://localhost:8086
+org=my-org
+token=my-token
+timeout=6000
+ssl_ca_cert=/path/to/my/cert
+
+[tags]
+id = 132-987-655
+customer = California Miner
+data_center = ${env.data_center}


### PR DESCRIPTION
Closes #157

## Proposed Changes

- added possibility to specify certificate file path to verify the peer

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
