### PR TITLE
chore: aws lambda layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,19 @@ jobs:
           command: |
             pip install pydocstyle --user
             pydocstyle --count influxdb_client
+  check-aws-lambda-layer:
+    docker:
+      - image: docker:19
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Create Archive to upload as a custom Lambda Layer
+          command: |
+            cd docker/aws_lambda_layer
+            docker build -t lambdalayer:latest .
+            docker create --name lambdalayer lambdalayer:latest
+            docker cp lambdalayer:/install/python.zip .
 
 workflows:
   version: 2
@@ -141,3 +154,4 @@ workflows:
                 - master
     jobs:
       - tests-python
+      - check-aws-lambda-layer

--- a/docker/aws_lambda_layer/Dockerfile
+++ b/docker/aws_lambda_layer/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazonlinux:2
+RUN mkdir /install
+WORKDIR /install
+RUN yum install -y amazon-linux-extras
+RUN amazon-linux-extras enable python3.8
+RUN yum install -y python38 python38-devel python3-pip zip gcc
+RUN python3.8 -m pip install --upgrade pip && \
+    python3.8 -m pip install virtualenv
+RUN python3.8 -m venv lambda
+RUN source lambda/bin/activate
+# Python dependencies to be included in output zip file:
+RUN python3.8 -m pip install influxdb-client[ciso] -t /install/python
+# Create zip file
+RUN zip -r /install/python.zip python/
+VOLUME ["/install"]

--- a/docker/aws_lambda_layer/README.md
+++ b/docker/aws_lambda_layer/README.md
@@ -1,0 +1,18 @@
+## AWS Lambda Layer Docker image
+Docker image which allows user to create a zip file with all Python dependencies for a custom AWS Lambda function (by default with influxdb-client). This should be within the limit of 10MB per single browser upload (~3,5MB with just the influxdb-client-python library). If the zip archive is uploaded to a custom Lambda Layer then user is able to keep using the Console IDE for editing main Lambda function.
+### Build image:
+`docker build -t lambdalayer:latest .`
+### Create container:
+`docker create --name lambdalayer lambdalayer:latest`
+### Copy zip from container:
+`docker cp lambdalayer:/install/python.zip .`
+### Upload zip to AWS Lambda
+Use AWS CLI or AWS Console to create and upload archive to a custom Lambda Layer. Then import those dependencies in lambda function as usual.
+```
+...
+from influxdb_client import InfluxDBClient, Point
+...
+```
+### Reference:
+https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies
+https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-using


### PR DESCRIPTION
Closes #106 

## Proposed Changes

Docker image which allows user to create a zip file with all Python dependencies for a custom AWS Lambda function (by default with influxdb-client). This should be within the limit of 10MB per single browser upload (~3,5MB with just the influxdb-client-python library). If the zip archive is uploaded to a custom Lambda Layer then user is able to keep using the Console IDE for editing main Lambda function.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)