### PR TITLE
feat: added logging message for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.12.0 [unreleased]
 
+### Features
+1. [#161](https://github.com/influxdata/influxdb-client-python/pull/161): Added logging message for retries
+
 ## 1.11.0 [2020-10-02]
 
 ### Features

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -1,0 +1,37 @@
+"""Exceptions utils for InfluxDB."""
+
+import logging
+
+from urllib3 import HTTPResponse
+
+logger = logging.getLogger(__name__)
+
+
+class InfluxDBError(Exception):
+    """Raised when a server error occurs."""
+
+    def __init__(self, response: HTTPResponse):
+        """Initialize the InfluxDBError handler."""
+        self.response = response
+        self.message = self._get_message(response)
+        self.retry_after = response.getheader('Retry-After')
+        super().__init__(self.message)
+
+    def _get_message(self, response):
+        # Body
+        if response.data:
+            import json
+            try:
+                return json.loads(response.data)["message"]
+            except Exception as e:
+                logging.debug(f"Cannot parse error response to JSON: {response.data}, {e}")
+                return response.data
+
+        # Header
+        for header_key in ["X-Platform-Error-Code", "X-Influx-Error", "X-InfluxDb-Error"]:
+            header_value = response.getheader(header_key)
+            if header_value is not None:
+                return header_value
+
+        # Http Status
+        return response.reason

--- a/tests/test_InfluxDBError.py
+++ b/tests/test_InfluxDBError.py
@@ -1,0 +1,48 @@
+import unittest
+
+from urllib3 import HTTPResponse
+
+from influxdb_client.client.exceptions import InfluxDBError
+
+
+class TestInfluxDBError(unittest.TestCase):
+    def test_response(self):
+        response = HTTPResponse()
+        self.assertEqual(response, InfluxDBError(response=response).response)
+
+    def test_message(self):
+
+        response = HTTPResponse()
+        response.headers.add('X-Platform-Error-Code', 'too many requests 1')
+        self.assertEqual("too many requests 1", str(InfluxDBError(response=response)))
+
+        response = HTTPResponse()
+        response.headers.add('X-Influx-Error', 'too many requests 2')
+        self.assertEqual("too many requests 2", str(InfluxDBError(response=response)))
+
+        response = HTTPResponse()
+        response.headers.add('X-InfluxDb-Error', 'too many requests 3')
+        self.assertEqual("too many requests 3", str(InfluxDBError(response=response)))
+
+        response = HTTPResponse(body='{"code":"too many requests","message":"org 04014de4ed590000 has exceeded limited_write plan limit"}')
+        response.headers.add('X-InfluxDb-Error', 'error 3')
+        self.assertEqual("org 04014de4ed590000 has exceeded limited_write plan limit", str(InfluxDBError(response=response)))
+
+        response = HTTPResponse(body='org 04014de4ed590000 has exceeded limited_write plan limit')
+        response.headers.add('X-InfluxDb-Error', 'error 3')
+        self.assertEqual("org 04014de4ed590000 has exceeded limited_write plan limit", str(InfluxDBError(response=response)))
+
+        response = HTTPResponse(reason='too many requests 4')
+        self.assertEqual("too many requests 4", str(InfluxDBError(response=response)))
+
+    def test_message_get_retry_after(self):
+        response = HTTPResponse(reason="too many requests")
+        response.headers.add('Retry-After', '63')
+
+        influx_db_error = InfluxDBError(response=response)
+        self.assertEqual("too many requests", str(influx_db_error))
+        self.assertEqual("63", influx_db_error.retry_after)
+
+        influx_db_error = InfluxDBError(response=HTTPResponse(reason="too many requests"))
+        self.assertEqual("too many requests", str(influx_db_error))
+        self.assertEqual(None, influx_db_error.retry_after)


### PR DESCRIPTION
## Proposed Changes

* message scope is **warning**
* The message looks like:
 _The retriable error occurred during request. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in 63s._
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
