### PR TITLE
fix: skip DataFrame rows without data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.13.0 [unreleased]
 
+### Bug Fixes
+1. [#164](https://github.com/influxdata/influxdb-client-python/pull/170): Skip DataFrame rows without data - all fields are nan. 
+
+
 ## 1.12.0 [2020-10-30]
 
 1. [#163](https://github.com/influxdata/influxdb-client-python/pull/163): Added support for Python 3.9

--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -99,9 +99,10 @@ class DataSerializerTest(unittest.TestCase):
         data_frame = pd.DataFrame(data=[[3.1955, np.nan, 20.514305, np.nan],
                                         [5.7310, np.nan, 23.328710, np.nan],
                                         [np.nan, 3.138664, np.nan, 20.755026],
-                                        [5.7310, 5.139563, 23.328710, 19.791240]],
+                                        [5.7310, 5.139563, 23.328710, 19.791240],
+                                        [np.nan, np.nan, np.nan, np.nan]],
                                   index=[now, now + timedelta(minutes=30), now + timedelta(minutes=60),
-                                         now + timedelta(minutes=90)],
+                                         now + timedelta(minutes=90), now + timedelta(minutes=120)],
                                   columns=["actual_kw_price", "forecast_kw_price", "actual_general_use",
                                            "forecast_general_use"])
 


### PR DESCRIPTION
Closes #169 

## Proposed Changes

Skip DataFrame rows without data - all fields are nan

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
