### PR TITLE
feat: Allow providing proxy option to InfluxDBClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.14.0 [unreleased]
 
+### Features
+1. [#176](https://github.com/influxdata/influxdb-client-python/pull/176): Allow providing proxy option to InfluxDBClient
+
 ## 1.13.0 [2020-12-04]
 
 ### Features

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -54,6 +54,7 @@ class InfluxDBClient(object):
         conf.debug = debug
         conf.verify_ssl = kwargs.get('verify_ssl', True)
         conf.ssl_ca_cert = kwargs.get('ssl_ca_cert', None)
+        conf.proxy = kwargs.get('proxy', None)
 
         auth_token = self.token
         auth_header_name = "Authorization"

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -34,6 +34,7 @@ class InfluxDBClient(object):
         :param org: organization name (used as a default in query and write API)
         :key bool verify_ssl: Set this to false to skip verifying SSL certificate when calling API from https server.
         :key str ssl_ca_cert: Set this to customize the certificate file to verify the peer.
+        :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
                                                except batching writes. As a default there is no one retry strategy.
 


### PR DESCRIPTION
Helps with #176 

## Proposed Changes

Allow passing proxy setting as options to the `InfluxDBClient`.

For example:

```
client = InfluxDBClient(url="https://public-url", token=token, org=org, proxy="http://127.0.0.1:3128")
```
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
