### PR TITLE
chore: use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/docker/aws_lambda_layer/Dockerfile
+++ b/docker/aws_lambda_layer/Dockerfile
@@ -4,12 +4,12 @@ WORKDIR /install
 RUN yum install -y amazon-linux-extras
 RUN amazon-linux-extras enable python3.8
 RUN yum install -y python38 python38-devel python3-pip zip gcc
-RUN python3.8 -m pip install --upgrade pip && \
-    python3.8 -m pip install virtualenv
+RUN python3.8 -m pip install --no-cache-dir --upgrade pip && \
+    python3.8 -m pip install --no-cache-dir virtualenv
 RUN python3.8 -m venv lambda
 RUN source lambda/bin/activate
 # Python dependencies to be included in output zip file:
-RUN python3.8 -m pip install influxdb-client[ciso] -t /install/python
+RUN python3.8 -m pip install --no-cache-dir influxdb-client[ciso] -t /install/python
 # Create zip file
 RUN zip -r /install/python.zip python/
 VOLUME ["/install"]


### PR DESCRIPTION
## Proposed Changes

using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [*] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [*] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
