### PR TITLE
fix(tasks_api): fixed get_run to use proper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.15.0 [unreleased]
 
+### Bug Fixes
+1. [#193](https://github.com/influxdata/influxdb-client-python/pull/193): Fixed `tasks_api` to use proper function to get `Run`
+
 ## 1.14.0 [2021-01-29]
 
 ### Features

--- a/influxdb_client/client/tasks_api.py
+++ b/influxdb_client/client/tasks_api.py
@@ -165,7 +165,7 @@ class TasksApi(object):
         :param run_id: run id
         :return: Run for specified task and run id
         """
-        return self._service.get_tasks_id_runs(task_id=task_id, run_id=run_id)
+        return self._service.get_tasks_id_runs_id(task_id=task_id, run_id=run_id)
 
     def get_run_logs(self, task_id: str, run_id: str) -> List['LogEvent']:
         """Retrieve all logs for a run."""

--- a/tests/test_TasksApi.py
+++ b/tests/test_TasksApi.py
@@ -381,3 +381,13 @@ class TasksApiTest(BaseTest):
             assert self.tasks_api.cancel_run("020f755c3c082000", "020f755c3c082000")
         assert "failed to cancel run" in e.value.body
         assert "task not found" in e.value.body
+
+    def test_get_run(self):
+        task = self.tasks_api.create_task_every(self.generate_name("it task"), TASK_FLUX, "1s", self.organization)
+        time.sleep(5)
+        run = self.tasks_api.get_runs(task_id=task.id)[0]
+        self.assertIsNotNone(run)
+        run_by_id = self.tasks_api.get_run(task.id, run.id)
+        self.assertIsNotNone(run_by_id)
+        self.assertEqual(run.id, run_by_id.id)
+


### PR DESCRIPTION
Closes #

## Proposed Changes

_Briefly describe your proposed changes:_
I was trying to get a single run for a task and was getting the following error:
`Got an unexpected keyword argument 'run_id' to method get_tasks_id_runs`

From what I could tell, the lib was using the wrong function to get a specific run by id.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
