### PR TITLE
docs: fix an example about how to write Pandas.DataFrame

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -334,7 +334,7 @@ The batching is configurable by ``write_options``\ :
                               index=[now, now + timedelta(hours=1)],
                               columns=["location", "water_level"])
 
-   _write_client.write(bucket.name, record=data_frame, data_frame_measurement_name='h2o_feet',
+   _write_client.write("my-bucket", "my-org", record=data_frame, data_frame_measurement_name='h2o_feet',
                        data_frame_tag_columns=['location'])
 
    """

--- a/README.rst
+++ b/README.rst
@@ -271,77 +271,82 @@ The batching is configurable by ``write_options``\ :
 
 .. code-block:: python
 
-   import rx
-   from rx import operators as ops
+    from datetime import datetime, timedelta
 
-   from influxdb_client import InfluxDBClient, Point, WriteOptions
-   from influxdb_client.client.write_api import SYNCHRONOUS
+    import pandas as pd
+    import rx
+    from pytz import UTC
+    from rx import operators as ops
 
-   _client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
-   _write_client = _client.write_api(write_options=WriteOptions(batch_size=500,
-                                                                flush_interval=10_000,
-                                                                jitter_interval=2_000,
-                                                                retry_interval=5_000,
-                                                                max_retries=5,
-                                                                max_retry_delay=30_000,
-                                                                exponential_base=2))
+    from influxdb_client import InfluxDBClient, Point, WriteOptions
 
-   """
-   Write Line Protocol formatted as string
-   """
-   _write_client.write("my-bucket", "my-org", "h2o_feet,location=coyote_creek water_level=1.0 1")
-   _write_client.write("my-bucket", "my-org", ["h2o_feet,location=coyote_creek water_level=2.0 2",
-                                               "h2o_feet,location=coyote_creek water_level=3.0 3"])
+    _client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
+    _write_client = _client.write_api(write_options=WriteOptions(batch_size=500,
+                                                                 flush_interval=10_000,
+                                                                 jitter_interval=2_000,
+                                                                 retry_interval=5_000,
+                                                                 max_retries=5,
+                                                                 max_retry_delay=30_000,
+                                                                 exponential_base=2))
 
-   """
-   Write Line Protocol formatted as byte array
-   """
-   _write_client.write("my-bucket", "my-org", "h2o_feet,location=coyote_creek water_level=1.0 1".encode())
-   _write_client.write("my-bucket", "my-org", ["h2o_feet,location=coyote_creek water_level=2.0 2".encode(),
-                                               "h2o_feet,location=coyote_creek water_level=3.0 3".encode()])
+    """
+    Write Line Protocol formatted as string
+    """
+    _write_client.write("my-bucket", "my-org", "h2o_feet,location=coyote_creek water_level=1.0 1")
+    _write_client.write("my-bucket", "my-org", ["h2o_feet,location=coyote_creek water_level=2.0 2",
+                                                "h2o_feet,location=coyote_creek water_level=3.0 3"])
 
-   """
-   Write Dictionary-style object
-   """
-   _write_client.write("my-bucket", "my-org", {"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
-                                               "fields": {"water_level": 1.0}, "time": 1})
-   _write_client.write("my-bucket", "my-org", [{"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
-                                               "fields": {"water_level": 2.0}, "time": 2},
-                                               {"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
-                                               "fields": {"water_level": 3.0}, "time": 3}])
+    """
+    Write Line Protocol formatted as byte array
+    """
+    _write_client.write("my-bucket", "my-org", "h2o_feet,location=coyote_creek water_level=1.0 1".encode())
+    _write_client.write("my-bucket", "my-org", ["h2o_feet,location=coyote_creek water_level=2.0 2".encode(),
+                                                "h2o_feet,location=coyote_creek water_level=3.0 3".encode()])
 
-   """
-   Write Data Point
-   """
-   _write_client.write("my-bucket", "my-org", Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 4.0).time(4))
-   _write_client.write("my-bucket", "my-org", [Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 5.0).time(5),
-                                               Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 6.0).time(6)])
+    """
+    Write Dictionary-style object
+    """
+    _write_client.write("my-bucket", "my-org", {"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
+                                                "fields": {"water_level": 1.0}, "time": 1})
+    _write_client.write("my-bucket", "my-org", [{"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
+                                                 "fields": {"water_level": 2.0}, "time": 2},
+                                                {"measurement": "h2o_feet", "tags": {"location": "coyote_creek"},
+                                                 "fields": {"water_level": 3.0}, "time": 3}])
 
-   """
-   Write Observable stream
-   """
-   _data = rx \
-       .range(7, 11) \
-       .pipe(ops.map(lambda i: "h2o_feet,location=coyote_creek water_level={0}.0 {0}".format(i)))
+    """
+    Write Data Point
+    """
+    _write_client.write("my-bucket", "my-org",
+                        Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 4.0).time(4))
+    _write_client.write("my-bucket", "my-org",
+                        [Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 5.0).time(5),
+                         Point("h2o_feet").tag("location", "coyote_creek").field("water_level", 6.0).time(6)])
 
-   _write_client.write("my-bucket", "my-org", _data)
+    """
+    Write Observable stream
+    """
+    _data = rx \
+        .range(7, 11) \
+        .pipe(ops.map(lambda i: "h2o_feet,location=coyote_creek water_level={0}.0 {0}".format(i)))
 
-   """
-   Write Pandas DataFrame
-   """
-   _now = pd.Timestamp().now('UTC')
-   _data_frame = pd.DataFrame(data=[["coyote_creek", 1.0], ["coyote_creek", 2.0]],
-                              index=[now, now + timedelta(hours=1)],
-                              columns=["location", "water_level"])
+    _write_client.write("my-bucket", "my-org", _data)
 
-   _write_client.write("my-bucket", "my-org", record=data_frame, data_frame_measurement_name='h2o_feet',
-                       data_frame_tag_columns=['location'])
+    """
+    Write Pandas DataFrame
+    """
+    _now = datetime.now(UTC)
+    _data_frame = pd.DataFrame(data=[["coyote_creek", 1.0], ["coyote_creek", 2.0]],
+                               index=[_now, _now + timedelta(hours=1)],
+                               columns=["location", "water_level"])
 
-   """
-   Close client
-   """
-   _write_client.__del__()
-   _client.__del__()
+    _write_client.write("my-bucket", "my-org", record=_data_frame, data_frame_measurement_name='h2o_feet',
+                        data_frame_tag_columns=['location'])
+
+    """
+    Close client
+    """
+    _write_client.__del__()
+    _client.__del__()
 
 .. marker-batching-end
 


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/commit/a1f9826590355e9cd32a198ae164560894c2bd58#r47111313

## Proposed Changes

Fixed an example about how to write Pandas.DataFrame

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
