### PR TITLE
docs: replace calls to __del__ with calls to close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 1. [#193](https://github.com/influxdata/influxdb-client-python/pull/193): Fixed `tasks_api` to use proper function to get `Run`
 
+### Documentation
+1. [#200](https://github.com/influxdata/influxdb-client-python/pull/200): Updated docs, examples, tests: use `close` instead of `__del__`.
+
 ## 1.14.0 [2021-01-29]
 
 ### Features

--- a/README.rst
+++ b/README.rst
@@ -345,8 +345,8 @@ The batching is configurable by ``write_options``\ :
     """
     Close client
     """
-    _write_client.__del__()
-    _client.__del__()
+    _write_client.close()
+    _client.close()
 
 .. marker-batching-end
 
@@ -436,7 +436,7 @@ Data are writes in an asynchronous HTTP request.
    async_result = write_api.write(bucket="my-bucket", record=[_point1, _point2])
    async_result.get()
 
-   client.__del__()
+   client.close()
 
 Synchronous client
 """"""""""""""""""
@@ -456,7 +456,7 @@ Data are writes in a synchronous HTTP request.
 
    write_api.write(bucket="my-bucket", record=[_point1, _point2])
 
-   client.__del__()
+   client.close()
 
 Queries
 ^^^^^^^
@@ -537,7 +537,7 @@ The API also support streaming ``FluxRecord`` via `query_stream <https://github.
     """
     Close client
     """
-    client.__del__()
+    client.close()
 
 Pandas DataFrame
 """"""""""""""""
@@ -580,7 +580,7 @@ The ``client`` is able to retrieve data in `Pandas DataFrame <https://pandas.pyd
     """
     Close client
     """
-    client.__del__()
+    client.close()
 
 Output:
 
@@ -677,7 +677,7 @@ If you would like to import gigabytes of data then use our multiprocessing examp
    Write data into InfluxDB
    """
    write_api.write(bucket="my-bucket", record=data)
-   write_api.__del__()
+   write_api.close()
 
    """
    Querying max value of CBOE Volatility Index
@@ -701,7 +701,7 @@ If you would like to import gigabytes of data then use our multiprocessing examp
    """
    Close client
    """
-   client.__del__()
+   client.close()
 
 .. marker-writes-end
 
@@ -734,8 +734,8 @@ Efficiency write data from IOT sensor
        :param write_api: WriteApi
        :return: nothing
        """
-       write_api.__del__()
-       db_client.__del__()
+       write_api.close()
+       db_client.close()
 
 
    def sensor_temperature():
@@ -930,7 +930,7 @@ The `delete_api.py <influxdb_client/client/delete_api.py>`_ supports deletes `po
     """
     Close client
     """
-    client.__del__()
+    client.close()
 
 .. marker-delete-end
 
@@ -1031,7 +1031,7 @@ that is replacement for python ``datetime.datetime`` object and also you should 
     """
     Close client
     """
-    client.__del__()
+    client.close()
 
 
 Local tests

--- a/examples/import_data_set.py
+++ b/examples/import_data_set.py
@@ -71,7 +71,7 @@ write_api = client.write_api(write_options=WriteOptions(batch_size=50_000, flush
 Write data into InfluxDB
 """
 write_api.write(bucket="my-bucket", record=data)
-write_api.__del__()
+write_api.close()
 
 """
 Querying max value of CBOE Volatility Index
@@ -95,4 +95,4 @@ for table in result:
 """
 Close client
 """
-client.__del__()
+client.close()

--- a/examples/import_data_set_multiprocessing.py
+++ b/examples/import_data_set_multiprocessing.py
@@ -60,8 +60,8 @@ class InfluxDBWriter(multiprocessing.Process):
         proc_name = self.name
         print()
         print('Writer: flushing data...')
-        self.write_api.__del__()
-        self.client.__del__()
+        self.write_api.close()
+        self.client.close()
         print('Writer: closed'.format(proc_name))
 
 
@@ -216,4 +216,4 @@ for table in result:
 """
 Close client
 """
-client.__del__()
+client.close()

--- a/examples/influxdb_18_example.py
+++ b/examples/influxdb_18_example.py
@@ -18,7 +18,7 @@ point = Point("mem").tag("host", "host1").field("used_percent", 25.43234543)
 print(point.to_line_protocol())
 
 write_api.write(bucket=bucket, record=point)
-write_api.__del__()
+write_api.close()
 
 print('*** Query Points ***')
 

--- a/examples/ingest_dataframe_default_tags.py
+++ b/examples/ingest_dataframe_default_tags.py
@@ -49,4 +49,4 @@ for table in result:
 """
 Close client
 """
-client.__del__()
+client.close()

--- a/examples/iot_sensor.py
+++ b/examples/iot_sensor.py
@@ -20,8 +20,8 @@ def on_exit(db_client: InfluxDBClient, write_api: WriteApi):
     :param write_api: WriteApi
     :return: nothing
     """
-    write_api.__del__()
-    db_client.__del__()
+    write_api.close()
+    db_client.close()
 
 
 def sensor_temperature():

--- a/examples/nanosecond_precision.py
+++ b/examples/nanosecond_precision.py
@@ -47,4 +47,4 @@ for record in records:
 """
 Close client
 """
-client.__del__()
+client.close()

--- a/examples/query.py
+++ b/examples/query.py
@@ -75,4 +75,4 @@ print(data_frame.to_string())
 """
 Close client
 """
-client.__del__()
+client.close()

--- a/examples/query_from_file.py
+++ b/examples/query_from_file.py
@@ -46,7 +46,7 @@ for table in tables:
 """
 Close client
 """
-client.__del__()
+client.close()
 
 
 

--- a/examples/rx_playground.py
+++ b/examples/rx_playground.py
@@ -54,6 +54,9 @@ class _RxWriter(object):
             .subscribe(self._result, self._error, self._on_complete)
         pass
 
+    def close(self):
+        self.__del__()
+
     def __del__(self):
         if self._subject:
             self._subject.on_completed()
@@ -179,8 +182,8 @@ rxWriter.write("balloon")
 print("\n== finish writing ==\n")
 time.sleep(5)
 
-print("\n== __del__ ==\n")
-rxWriter.__del__()
+print("\n== close ==\n")
+rxWriter.close()
 
 print("\n== finished ==\n")
 

--- a/notebooks/stock_predictions_import_data.py
+++ b/notebooks/stock_predictions_import_data.py
@@ -61,7 +61,7 @@ def main():
     write_api = client.write_api(write_options=WriteOptions(batch_size=50_000, flush_interval=10_000))
 
     write_api.write(bucket="my-bucket", record=data)
-    write_api.__del__()
+    write_api.close()
 
     query = '''
     from(bucket:"my-bucket")
@@ -78,7 +78,7 @@ def main():
     """
     Close client
     """
-    client.__del__()
+    client.close()
     # %%
 
 

--- a/tests/test_QueryApiDataFrame.py
+++ b/tests/test_QueryApiDataFrame.py
@@ -20,7 +20,7 @@ class QueryDataFrameApi(BaseTest):
         httpretty.reset()
 
     def tearDown(self) -> None:
-        self.client.__del__()
+        self.client.close()
         httpretty.disable()
 
     def test_one_table(self):
@@ -276,7 +276,7 @@ class QueryDataFrameIntegrationApi(BaseTest):
 
         write_api = self.client.write_api(write_options=WriteOptions(batch_size=500))
         write_api.write(org="my-org", bucket="my-bucket", record=data, write_precision=WritePrecision.S)
-        write_api.__del__()
+        write_api.close()
 
         query = 'from(bucket: "my-bucket")' \
                 '|> range(start: 2020-02-19T23:30:00Z, stop: now())' \

--- a/tests/test_QueryApiStream.py
+++ b/tests/test_QueryApiStream.py
@@ -15,7 +15,7 @@ class QueryStreamApi(BaseTest):
         self.bucket = self.create_test_bucket()
 
     def tearDown(self) -> None:
-        self.write_client.__del__()
+        self.write_client.close()
         super().tearDown()
 
     def test_block(self):

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -35,7 +35,7 @@ class SynchronousWriteTest(BaseTest):
                                                                                       '${env.data_center}'}))
 
     def tearDown(self) -> None:
-        self.write_client.__del__()
+        self.write_client.close()
         super().tearDown()
 
     def test_write_line_protocol(self):
@@ -425,7 +425,7 @@ class SynchronousWriteTest(BaseTest):
         self.assertEqual(401, exception.status)
         self.assertEqual("Unauthorized", exception.reason)
 
-        client.__del__()
+        client.close()
 
     def test_write_query_data_nanoseconds(self):
 
@@ -477,7 +477,7 @@ class WriteApiTestMock(BaseTest):
         self.influxdb_client = InfluxDBClient(url=conf.host, token="my-token")
 
     def tearDown(self) -> None:
-        self.influxdb_client.__del__()
+        self.influxdb_client.close()
         httpretty.disable()
 
     def test_writes_synchronous_without_retry(self):
@@ -521,7 +521,7 @@ class AsynchronousWriteTest(BaseTest):
                                                                                       '${env.data_center}'}))
 
     def tearDown(self) -> None:
-        self.write_client.__del__()
+        self.write_client.close()
         super().tearDown()
 
     def test_write_result(self):
@@ -723,7 +723,7 @@ class PointSettingTest(BaseTest):
         self.customer_tag = "California Miner"
 
     def tearDown(self) -> None:
-        self.write_client.__del__()
+        self.write_client.close()
         super().tearDown()
 
     def test_point_settings(self):
@@ -773,7 +773,7 @@ class DefaultTagsConfiguration(BaseTest):
         os.environ['INFLUXDB_V2_TAG_DATA_CENTER'] = "${env.data_center}"
 
     def tearDown(self) -> None:
-        self.write_client.__del__()
+        self.write_client.close()
         super().tearDown()
 
     def test_connection_option_from_conf_file(self):

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -31,7 +31,7 @@ class BatchingWriteTest(unittest.TestCase):
         self._write_client = WriteApi(influxdb_client=self.influxdb_client, write_options=self.write_options)
 
     def tearDown(self) -> None:
-        self._write_client.__del__()
+        self._write_client.close()
         httpretty.disable()
 
     def test_batch_size(self):
@@ -150,7 +150,7 @@ class BatchingWriteTest(unittest.TestCase):
                          httpretty.httpretty.latest_requests[1].parsed_body)
 
     def test_jitter_interval(self):
-        self._write_client.__del__()
+        self._write_client.close()
         self._write_client = WriteApi(influxdb_client=self.influxdb_client,
                                       write_options=WriteOptions(batch_size=2, flush_interval=5_000,
                                                                  jitter_interval=3_000))
@@ -179,7 +179,7 @@ class BatchingWriteTest(unittest.TestCase):
 
     def test_retry_interval(self):
 
-        self._write_client.__del__()
+        self._write_client.close()
 
         # Set retry interval to 1_500
         self.write_options = WriteOptions(batch_size=2, flush_interval=5_000, retry_interval=1_500)
@@ -226,7 +226,7 @@ class BatchingWriteTest(unittest.TestCase):
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=429,
                                adding_headers={'Retry-After': '1'})
 
-        self._write_client.__del__()
+        self._write_client.close()
         self._write_client = WriteApi(influxdb_client=self.influxdb_client,
                                       write_options=WriteOptions(batch_size=2, flush_interval=5_000, max_retries=5))
 
@@ -380,7 +380,7 @@ class BatchingWriteTest(unittest.TestCase):
         _record = "h2o_feet,location=coyote_creek level\\ water_level=1 1"
         _result = self._write_client.write("my-bucket", "my-org", _record)
 
-        self._write_client.__del__()
+        self._write_client.close()
 
         _requests = httpretty.httpretty.latest_requests
 
@@ -388,7 +388,7 @@ class BatchingWriteTest(unittest.TestCase):
         self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=1 1", _requests[0].parsed_body)
 
     def test_default_tags(self):
-        self._write_client.__del__()
+        self._write_client.close()
 
         self.id_tag = "132-987-655"
         self.customer_tag = "California Miner"
@@ -431,7 +431,7 @@ class BatchingWriteTest(unittest.TestCase):
 
     def test_to_low_flush_interval(self):
 
-        self._write_client.__del__()
+        self._write_client.close()
         self._write_client = WriteApi(influxdb_client=self.influxdb_client,
                                       write_options=WriteOptions(batch_size=8,
                                                                  flush_interval=1,
@@ -448,7 +448,7 @@ class BatchingWriteTest(unittest.TestCase):
             self._write_client.write("my-bucket", "my-org", [point_one, point_two])
             time.sleep(0.1)
 
-        self._write_client.__del__()
+        self._write_client.close()
 
         _requests = httpretty.httpretty.latest_requests
 

--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -21,7 +21,7 @@ class DataFrameWriteTest(BaseTest):
 
     def tearDown(self) -> None:
         super().tearDown()
-        self._write_client.__del__()
+        self._write_client.close()
 
     def test_write_num_py(self):
         from influxdb_client.extras import pd, np
@@ -38,7 +38,7 @@ class DataFrameWriteTest(BaseTest):
         write_api.write(bucket.name, record=data_frame, data_frame_measurement_name='h2o_feet',
                         data_frame_tag_columns=['location'])
 
-        write_api.__del__()
+        write_api.close()
 
         result = self.query_api.query(
             "from(bucket:\"" + bucket.name + "\") |> range(start: 1970-01-01T00:00:00.000000001Z)",

--- a/tests/test_WriteApiPickle.py
+++ b/tests/test_WriteApiPickle.py
@@ -19,8 +19,8 @@ class InfluxDBWriterToPickle:
         self.write_api.write(bucket="my-bucket", record=record)
 
     def terminate(self) -> None:
-        self.write_api.__del__()
-        self.client.__del__()
+        self.write_api.close()
+        self.client.close()
 
 
 class WriteApiPickle(BaseTest):

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -16,7 +16,7 @@ class GzipSupportTest(BaseTest):
         httpretty.reset()
 
     def tearDown(self) -> None:
-        self.client.__del__()
+        self.client.close()
         httpretty.disable()
 
     def test_gzip_disabled(self):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -44,7 +44,7 @@ class TestHealthMock(unittest.TestCase):
         self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token")
 
     def tearDown(self) -> None:
-        self.influxdb_client.__del__()
+        self.influxdb_client.close()
         httpretty.disable()
 
     def test_without_retry(self):
@@ -61,7 +61,7 @@ class TestHealthMock(unittest.TestCase):
 
     def test_with_retry(self):
 
-        self.influxdb_client.__del__()
+        self.influxdb_client.close()
         self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", retries=Retry())
 
         httpretty.register_uri(httpretty.GET, uri="http://localhost/health", status=200,


### PR DESCRIPTION
Related to #190.

## Proposed Changes

Use `close` rather than `__del__` in docs, tests and examples.

I could have added a close method to `ApiClient` for consistency but I didn't.

[This SO answer](https://stackoverflow.com/a/1481512/4653485) provides a nice explanation of what `__del__` is and its limitations and why using it is not a great pattern.

At least, I think the content should be in the close method, and the close method should be called in `__del__` rather than the opposite.

Anyway, as said in #190, a context manager would be a nice way of solving the whole thing.

Until then, I figured using `close` in the docs would be better.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
