### PR TITLE
feat: client could be configured via TOML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.16.0 [unreleased]
 
+### Features
+1. [#203](https://github.com/influxdata/influxdb-client-python/pull/203): Allow configuring client via TOML file.
+
 ### Documentation
 1. [#202](https://github.com/influxdata/influxdb-client-python/pull/202): Added an example how to use RxPY and sync batching
 

--- a/README.rst
+++ b/README.rst
@@ -379,7 +379,7 @@ _______
 Via Configuration file
 ______________________
 
-In a ini configuration file you are able to specify default tags by ``tags`` segment.
+In a `init <https://docs.python.org/3/library/configparser.html>`_ configuration file you are able to specify default tags by ``tags`` segment.
 
 .. code-block:: python
 
@@ -397,6 +397,8 @@ In a ini configuration file you are able to specify default tags by ``tags`` seg
     id = 132-987-655
     customer = California Miner
     data_center = ${env.data_center}
+
+You could also use a `TOML <https://toml.io/en/>`_ format for the configuration file.
 
 Via Environment Properties
 __________________________

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -69,44 +69,79 @@ class InfluxDBClient(object):
     @classmethod
     def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False):
         """
-        Configure client via '*.ini' file in segment 'influx2'.
+        Configure client via configuration file. The configuration has to be under 'influx' section.
 
-        Supported options:
+        The supported formats:
+            - https://docs.python.org/3/library/configparser.html
+            - https://toml.io/en/
+
+        Configuration options:
             - url
             - org
             - token
             - timeout,
             - verify_ssl
             - ssl_ca_cert
+
+        config.ini example::
+
+            [influx2]
+            url=http://localhost:8086
+            org=my-org
+            token=my-token
+            timeout=6000
+
+            [tags]
+            id = 132-987-655
+            customer = California Miner
+            data_center = ${env.data_center}
+
+        config.toml example::
+
+            [influx2]
+                url = "http://localhost:8086"
+                token = "my-token"
+                org = "my-org"
+                timeout = 6000
+
+            [tags]
+                id = "132-987-655"
+                customer = "California Miner"
+                data_center = "${env.data_center}"
+
         """
         config = configparser.ConfigParser()
         config.read(config_file)
 
-        url = config['influx2']['url']
-        token = config['influx2']['token']
+        def config_value(key: str):
+            return config['influx2'][key].strip('"')
+
+        url = config_value('url')
+        token = config_value('token')
 
         timeout = None
 
         if config.has_option('influx2', 'timeout'):
-            timeout = config['influx2']['timeout']
+            timeout = config_value('timeout')
 
         org = None
 
         if config.has_option('influx2', 'org'):
-            org = config['influx2']['org']
+            org = config_value('org')
 
         verify_ssl = True
         if config.has_option('influx2', 'verify_ssl'):
-            verify_ssl = config['influx2']['verify_ssl']
+            verify_ssl = config_value('verify_ssl')
 
         ssl_ca_cert = None
         if config.has_option('influx2', 'ssl_ca_cert'):
-            ssl_ca_cert = config['influx2']['ssl_ca_cert']
+            ssl_ca_cert = config_value('ssl_ca_cert')
 
         default_tags = None
 
         if config.has_section('tags'):
-            default_tags = dict(config.items('tags'))
+            tags = {k: v.strip('"') for k, v in config.items('tags')}
+            default_tags = dict(tags)
 
         if timeout:
             return cls(url, token, debug=debug, timeout=int(timeout), org=org, default_tags=default_tags,

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,0 +1,11 @@
+[influx2]
+  url = "http://localhost:8086"
+  token = "my-token"
+  org = "my-org"
+  active = true
+  timeout = 6000
+
+[tags]
+  id = "132-987-655"
+  customer = "California Miner"
+  data_center = "${env.data_center}"

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -47,6 +47,26 @@ class InfluxDBClientTest(unittest.TestCase):
         self.assertEqual(health.status, "pass")
         self.assertEqual(health.name, "influxdb")
 
+    def test_init_from_ini_file(self):
+        self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.ini')
+
+        self.assertConfig()
+
+    def test_init_from_toml_file(self):
+        self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.toml')
+
+        self.assertConfig()
+
+    def assertConfig(self):
+        self.assertEqual("http://localhost:8086", self.client.url)
+        self.assertEqual("my-org", self.client.org)
+        self.assertEqual("my-token", self.client.token)
+        self.assertEqual(6000, self.client.timeout)
+        self.assertEqual(3, len(self.client.default_tags))
+        self.assertEqual("132-987-655", self.client.default_tags["id"])
+        self.assertEqual("California Miner", self.client.default_tags["customer"])
+        self.assertEqual("${env.data_center}", self.client.default_tags["data_center"])
+
     def test_init_from_file_ssl_default(self):
         self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.ini')
 


### PR DESCRIPTION
Closes #201

## Proposed Changes

Allow configuring client via TOML file - InfluxDB 2 config file.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
