### PR TITLE
Remove the use of Mozilla's root certificates and certifi.where()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.16.0 [unreleased]
 
+### Bug Fixes
+1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Remove the use of Mozilla's root certificates and certifi.where()
+
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/pull/203): Allow configuring client via TOML file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.16.0 [unreleased]
 
-### Bug Fixes
-1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Remove the use of Mozilla's root certificates and certifi.where()
-
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/pull/203): Allow configuring client via TOML file.
+
+### Bug Fixes
+1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Use default (system) certificates instead of Mozilla's root certificates and certifi.where()
 
 ### Documentation
 1. [#202](https://github.com/influxdata/influxdb-client-python/pull/202): Added an example how to use RxPY and sync batching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#203](https://github.com/influxdata/influxdb-client-python/pull/203): Allow configuring client via TOML file.
 
 ### Bug Fixes
-1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Use default (system) certificates instead of Mozilla's root certificates and certifi.where()
+1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Use default (system) certificates instead of Mozilla's root certificates (certifi.where())
 
 ### Documentation
 1. [#202](https://github.com/influxdata/influxdb-client-python/pull/202): Added an example how to use RxPY and sync batching

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -18,7 +18,6 @@ import logging
 import re
 import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -85,8 +85,7 @@ class RESTClientObject(object):
         if configuration.ssl_ca_cert:
             ca_certs = configuration.ssl_ca_cert
         else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
+            ca_certs = None
 
         addition_pool_args = {}
         if configuration.assert_hostname is not None:


### PR DESCRIPTION
Closes #206

## Proposed Changes

Remove the use of Mozilla's root certificates as default.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
