### PR TITLE
feat(swagger): Allow setting shard-group durations for buckets via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Bug Fixes
 1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Use default (system) certificates instead of Mozilla's root certificates (certifi.where())
 
+### API
+1. [#209](https://github.com/influxdata/influxdb-client-python/pull/209): Allow setting shard-group durations for buckets via API
+
 ### Documentation
 1. [#202](https://github.com/influxdata/influxdb-client-python/pull/202): Added an example how to use RxPY and sync batching
 

--- a/influxdb_client/domain/bucket_retention_rules.py
+++ b/influxdb_client/domain/bucket_retention_rules.py
@@ -33,22 +33,27 @@ class BucketRetentionRules(object):
     """
     openapi_types = {
         'type': 'str',
-        'every_seconds': 'int'
+        'every_seconds': 'int',
+        'shard_group_duration_seconds': 'int'
     }
 
     attribute_map = {
         'type': 'type',
-        'every_seconds': 'everySeconds'
+        'every_seconds': 'everySeconds',
+        'shard_group_duration_seconds': 'shardGroupDurationSeconds'
     }
 
-    def __init__(self, type='expire', every_seconds=None):  # noqa: E501,D401,D403
+    def __init__(self, type='expire', every_seconds=None, shard_group_duration_seconds=None):  # noqa: E501,D401,D403
         """BucketRetentionRules - a model defined in OpenAPI."""  # noqa: E501
         self._type = None
         self._every_seconds = None
+        self._shard_group_duration_seconds = None
         self.discriminator = None
 
         self.type = type
         self.every_seconds = every_seconds
+        if shard_group_duration_seconds is not None:
+            self.shard_group_duration_seconds = shard_group_duration_seconds
 
     @property
     def type(self):
@@ -74,7 +79,7 @@ class BucketRetentionRules(object):
     def every_seconds(self):
         """Get the every_seconds of this BucketRetentionRules.
 
-        Duration in seconds for how long data will be kept in the database.
+        Duration in seconds for how long data will be kept in the database. 0 means infinite.
 
         :return: The every_seconds of this BucketRetentionRules.
         :rtype: int
@@ -85,16 +90,38 @@ class BucketRetentionRules(object):
     def every_seconds(self, every_seconds):
         """Set the every_seconds of this BucketRetentionRules.
 
-        Duration in seconds for how long data will be kept in the database.
+        Duration in seconds for how long data will be kept in the database. 0 means infinite.
 
         :param every_seconds: The every_seconds of this BucketRetentionRules.
         :type: int
         """  # noqa: E501
         if every_seconds is None:
             raise ValueError("Invalid value for `every_seconds`, must not be `None`")  # noqa: E501
-        if every_seconds is not None and every_seconds < 1:  # noqa: E501
-            raise ValueError("Invalid value for `every_seconds`, must be a value greater than or equal to `1`")  # noqa: E501
+        if every_seconds is not None and every_seconds < 0:  # noqa: E501
+            raise ValueError("Invalid value for `every_seconds`, must be a value greater than or equal to `0`")  # noqa: E501
         self._every_seconds = every_seconds
+
+    @property
+    def shard_group_duration_seconds(self):
+        """Get the shard_group_duration_seconds of this BucketRetentionRules.
+
+        Shard duration measured in seconds.
+
+        :return: The shard_group_duration_seconds of this BucketRetentionRules.
+        :rtype: int
+        """  # noqa: E501
+        return self._shard_group_duration_seconds
+
+    @shard_group_duration_seconds.setter
+    def shard_group_duration_seconds(self, shard_group_duration_seconds):
+        """Set the shard_group_duration_seconds of this BucketRetentionRules.
+
+        Shard duration measured in seconds.
+
+        :param shard_group_duration_seconds: The shard_group_duration_seconds of this BucketRetentionRules.
+        :type: int
+        """  # noqa: E501
+        self._shard_group_duration_seconds = shard_group_duration_seconds
 
     def to_dict(self):
         """Return the model properties as a dict."""

--- a/influxdb_client/domain/date_time_literal.py
+++ b/influxdb_client/domain/date_time_literal.py
@@ -33,7 +33,7 @@ class DateTimeLiteral(object):
     """
     openapi_types = {
         'type': 'str',
-        'value': 'str'
+        'value': 'datetime'
     }
 
     attribute_map = {
@@ -79,7 +79,7 @@ class DateTimeLiteral(object):
         """Get the value of this DateTimeLiteral.
 
         :return: The value of this DateTimeLiteral.
-        :rtype: str
+        :rtype: datetime
         """  # noqa: E501
         return self._value
 
@@ -88,7 +88,7 @@ class DateTimeLiteral(object):
         """Set the value of this DateTimeLiteral.
 
         :param value: The value of this DateTimeLiteral.
-        :type: str
+        :type: datetime
         """  # noqa: E501
         self._value = value
 

--- a/tests/test_BucketsApi.py
+++ b/tests/test_BucketsApi.py
@@ -71,9 +71,8 @@ class BucketsClientTest(BaseTest):
 
         bucket_name = generate_bucket_name()
 
-        retention = BucketRetentionRules
         ret_list = []
-        retention.every_seconds = 3600
+        retention = BucketRetentionRules(every_seconds=3600)
         retention.type = "expire"
         ret_list.append(retention)
 


### PR DESCRIPTION
The generated API validate values in domain object.

The https://github.com/influxdata/influxdb/pull/20911 change api:

![image](https://user-images.githubusercontent.com/455137/111181154-f8816c80-85ad-11eb-8aa5-dab07102fa7d.png)

so our integrations test agains nightly build failing:

![image](https://user-images.githubusercontent.com/455137/111181298-1f3fa300-85ae-11eb-9edc-8ab8e475d8ba.png)

https://app.circleci.com/pipelines/github/influxdata/influxdb-client-python/832/workflows/ced8a9ae-fc23-46bf-8ec9-a4daed7dd94c/jobs/2923