### PR TITLE
docs: added an example how to use `Buckets` API

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,10 @@
 - [query.py](query.py) - How to query data into `FluxTable`s, `Stream` and `CSV`
 - [query_from_file.py](query_from_file.py) - How to use a Flux query defined in a separate file
 
+
+## Management API
+- [buckets_management.py](buckets_management.py) -How to How to create, list and delete Buckets
+
 ## Others
 - [influx_cloud.py](influx_cloud.py) - How to connect to InfluxDB 2 Cloud
 - [influxdb_18_example.py](influxdb_18_example.py) - How to connect to InfluxDB 1.8

--- a/examples/buckets_management.py
+++ b/examples/buckets_management.py
@@ -1,0 +1,48 @@
+"""
+How to How to create, list and delete Buckets.
+"""
+
+from influxdb_client import InfluxDBClient, BucketRetentionRules
+
+"""
+Define credentials
+"""
+url = "http://localhost:8086"
+token = "my-token"
+
+client = InfluxDBClient(url=url, token=token)
+buckets_api = client.buckets_api()
+
+"""
+The Bucket API uses as a parameter the Organization ID. We have to retrieve ID by Organization API.
+"""
+org_name = "my-org"
+org = list(filter(lambda it: it.name == org_name, client.organizations_api().find_organizations()))[0]
+
+"""
+Create Bucket with retention policy set to 3600 seconds and name "bucket-by-python"
+"""
+print(f"------- Create -------\n")
+retention_rules = BucketRetentionRules(type="expire", every_seconds=3600)
+created_bucket = buckets_api.create_bucket(bucket_name="bucket-by-python",
+                                           retention_rules=retention_rules,
+                                           org_id=org.id)
+print(created_bucket)
+
+"""
+List all Buckets
+"""
+print(f"\n------- List -------\n")
+buckets = buckets_api.find_buckets().buckets
+print("\n".join([f" ---\n ID: {bucket.id}\n Name: {bucket.name}\n Retention: {bucket.retention_rules}"
+                 for bucket in buckets]))
+print("---")
+
+"""
+Delete previously created bucket
+"""
+print(f"------- Delete -------\n")
+buckets_api.delete_bucket(created_bucket)
+print(f" successfully deleted bucket: {created_bucket.name}")
+
+client.close()


### PR DESCRIPTION
Closes #210

## Proposed Changes

Added an example how to use `Buckets` API.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
