### PR TITLE
feat:  query bind parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.17.0 [unreleased]
 
+### Features
+1. [#203](https://github.com/influxdata/influxdb-client-python/issues/219): Bind query parameters 
+
 ## 1.16.0 [2021-04-01]
 
 ### Features

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -45,8 +45,8 @@ class QueryApi(object):
         """
         if org is None:
             org = self._influxdb_client.org
-        response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params), async_req=False,
-                                              _preload_content=False)
+        response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params),
+                                              async_req=False, _preload_content=False)
 
         return csv.reader(codecs.iterdecode(response, 'utf-8'))
 
@@ -67,7 +67,7 @@ class QueryApi(object):
 
         return result
 
-    def query(self, query: str, org=None,  params: dict = None) -> List['FluxTable']:
+    def query(self, query: str, org=None, params: dict = None) -> List['FluxTable']:
         """
         Execute synchronous Flux query and return result as a List['FluxTable'].
 
@@ -201,7 +201,7 @@ class QueryApi(object):
         if params is None:
             return None
 
-        return File(package=None, name=None, type=None, imports=[],  body=QueryApi._params_to_extern_ast(params))
+        return File(package=None, name=None, type=None, imports=[], body=QueryApi._params_to_extern_ast(params))
 
     def __del__(self):
         """Close QueryAPI."""

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -93,7 +93,6 @@ class QueryApi(object):
         Execute synchronous Flux query and return stream of FluxRecord as a Generator['FluxRecord'].
 
         :param query: the Flux query
-        :param params: the Flux query parameters
         :param org: organization name (optional if already specified in InfluxDBClient)
         :param params: bind parameters
         :return:

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -6,9 +6,12 @@ Flux is InfluxData’s functional data scripting language designed for querying,
 
 import codecs
 import csv
+from datetime import datetime, timedelta
 from typing import List, Generator, Any
+from pytz import UTC
 
-from influxdb_client import Dialect
+from influxdb_client import Dialect, IntegerLiteral, BooleanLiteral, FloatLiteral, DateTimeLiteral, StringLiteral, \
+    VariableAssignment, Identifier, OptionStatement, File, DurationLiteral, Duration, UnaryExpression
 from influxdb_client import Query, QueryService
 from influxdb_client.client.flux_csv_parser import FluxCsvParser, FluxSerializationMode
 from influxdb_client.client.flux_table import FluxTable, FluxRecord
@@ -29,51 +32,54 @@ class QueryApi(object):
         self._influxdb_client = influxdb_client
         self._query_api = QueryService(influxdb_client.api_client)
 
-    def query_csv(self, query: str, org=None, dialect: Dialect = default_dialect):
+    def query_csv(self, query: str, org=None, dialect: Dialect = default_dialect, params: dict = None):
         """
         Execute the Flux query and return results as a CSV iterator. Each iteration returns a row of the CSV file.
 
         :param query: a Flux query
         :param org: organization name (optional if already specified in InfluxDBClient)
         :param dialect: csv dialect format
+        :param params: bind parameters
         :return: The returned object is an iterator.  Each iteration returns a row of the CSV file
                  (which can span multiple input lines).
         """
         if org is None:
             org = self._influxdb_client.org
-        response = self._query_api.post_query(org=org, query=self._create_query(query, dialect), async_req=False,
+        response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params), async_req=False,
                                               _preload_content=False)
 
         return csv.reader(codecs.iterdecode(response, 'utf-8'))
 
-    def query_raw(self, query: str, org=None, dialect=default_dialect):
+    def query_raw(self, query: str, org=None, dialect=default_dialect, params: dict = None):
         """
         Execute synchronous Flux query and return result as raw unprocessed result as a str.
 
         :param query: a Flux query
         :param org: organization name (optional if already specified in InfluxDBClient)
         :param dialect: csv dialect format
+        :param params: bind parameters
         :return: str
         """
         if org is None:
             org = self._influxdb_client.org
-        result = self._query_api.post_query(org=org, query=self._create_query(query, dialect), async_req=False,
+        result = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params), async_req=False,
                                             _preload_content=False)
 
         return result
 
-    def query(self, query: str, org=None) -> List['FluxTable']:
+    def query(self, query: str, org=None,  params: dict = None) -> List['FluxTable']:
         """
         Execute synchronous Flux query and return result as a List['FluxTable'].
 
         :param query: the Flux query
         :param org: organization name (optional if already specified in InfluxDBClient)
+        :param params: bind parameters
         :return:
         """
         if org is None:
             org = self._influxdb_client.org
 
-        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect),
+        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
 
         _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.tables)
@@ -82,12 +88,14 @@ class QueryApi(object):
 
         return _parser.tables
 
-    def query_stream(self, query: str, org=None) -> Generator['FluxRecord', Any, None]:
+    def query_stream(self, query: str, org=None, params: dict = None) -> Generator['FluxRecord', Any, None]:
         """
         Execute synchronous Flux query and return stream of FluxRecord as a Generator['FluxRecord'].
 
         :param query: the Flux query
+        :param params: the Flux query parameters
         :param org: organization name (optional if already specified in InfluxDBClient)
+        :param params: bind parameters
         :return:
         """
         if org is None:
@@ -100,7 +108,7 @@ class QueryApi(object):
 
         return _parser.generator()
 
-    def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None):
+    def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
         """
         Execute synchronous Flux query and return Pandas DataFrame.
 
@@ -109,11 +117,12 @@ class QueryApi(object):
         :param query: the Flux query
         :param org: organization name (optional if already specified in InfluxDBClient)
         :param data_frame_index: the list of columns that are used as DataFrame index
+        :param params: bind parameters
         :return:
         """
         from ..extras import pd
 
-        _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index)
+        _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index, params=params)
         _dataFrames = list(_generator)
 
         if len(_dataFrames) == 0:
@@ -123,7 +132,7 @@ class QueryApi(object):
         else:
             return _dataFrames
 
-    def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None):
+    def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
         """
         Execute synchronous Flux query and return stream of Pandas DataFrame as a Generator['pd.DataFrame'].
 
@@ -132,12 +141,13 @@ class QueryApi(object):
         :param query: the Flux query
         :param org: organization name (optional if already specified in InfluxDBClient)
         :param data_frame_index: the list of columns that are used as DataFrame index
+        :param params: bind parameters
         :return:
         """
         if org is None:
             org = self._influxdb_client.org
 
-        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect),
+        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
 
         _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.dataFrame,
@@ -146,9 +156,52 @@ class QueryApi(object):
 
     # private helper for c
     @staticmethod
-    def _create_query(query, dialect=default_dialect):
-        created = Query(query=query, dialect=dialect)
+    def _create_query(query, dialect=default_dialect, params: dict = None):
+        created = Query(query=query, dialect=dialect, extern=QueryApi._build_flux_ast(params))
         return created
+
+    @staticmethod
+    def _params_to_extern_ast(params: dict) -> List['OptionStatement']:
+
+        statements = []
+        for key, value in params.items():
+
+            if isinstance(value, bool):
+                literal = BooleanLiteral("BooleanLiteral", value)
+            elif isinstance(value, int):
+                literal = IntegerLiteral("IntegerLiteral", str(value))
+            elif isinstance(value, float):
+                literal = FloatLiteral("FloatLiteral", value)
+            elif isinstance(value, datetime):
+                if not value.tzinfo:
+                    value = UTC.localize(value)
+                else:
+                    value = value.astimezone(UTC)
+                literal = DateTimeLiteral("DateTimeLiteral", value.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
+            elif isinstance(value, timedelta):
+                # convert to microsecodns
+                _micro_delta = int(value / timedelta(microseconds=1))
+                if _micro_delta < 0:
+                    literal = UnaryExpression("UnaryExpression", argument=DurationLiteral("DurationLiteral", [
+                        Duration(magnitude=-_micro_delta, unit="us")]), operator="-")
+                else:
+                    literal = DurationLiteral("DurationLiteral", [Duration(magnitude=_micro_delta, unit="us")])
+            elif isinstance(value, str):
+                literal = StringLiteral("StringLiteral", str(value))
+            else:
+                literal = value
+
+            statements.append(OptionStatement("OptionStatement",
+                                              VariableAssignment("VariableAssignment", Identifier("Identifier", key),
+                                                                 literal)))
+        return statements
+
+    @staticmethod
+    def _build_flux_ast(params: dict = None):
+        if params is None:
+            return None
+
+        return File(package=None, name=None, type=None, imports=[],  body=QueryApi._params_to_extern_ast(params))
 
     def __del__(self):
         """Close QueryAPI."""

--- a/influxdb_client/client/util/date_utils.py
+++ b/influxdb_client/client/util/date_utils.py
@@ -1,6 +1,8 @@
 """Utils to get right Date parsing function."""
+import datetime
 
 from dateutil import parser
+from pytz import UTC
 
 date_helper = None
 
@@ -29,6 +31,18 @@ class DateHelper:
         nanoseconds_in_micros = delta.microseconds * 10 ** 3
 
         return nanoseconds_in_days + nanoseconds_in_seconds + nanoseconds_in_micros
+
+    def to_utc(self, value: datetime):
+        """
+        Convert datetime to UTC timezone.
+
+        :param value: datetime
+        :return: datetime in UTC
+        """
+        if not value.tzinfo:
+            return UTC.localize(value)
+        else:
+            return value.astimezone(UTC)
 
 
 def get_date_helper() -> DateHelper:

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -204,11 +204,7 @@ def _convert_timestamp(timestamp, precision=DEFAULT_WRITE_PRECISION):
     if isinstance(timestamp, timedelta) or isinstance(timestamp, datetime):
 
         if isinstance(timestamp, datetime):
-            if not timestamp.tzinfo:
-                timestamp = UTC.localize(timestamp)
-            else:
-                timestamp = timestamp.astimezone(UTC)
-            timestamp = timestamp - EPOCH
+            timestamp = date_helper.to_utc(timestamp) - EPOCH
 
         ns = date_helper.to_nanoseconds(timestamp)
 

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -1,5 +1,9 @@
+import datetime
+import json
 import unittest
 
+from influxdb_client import QueryApi, DurationLiteral, Duration, CallExpression, Expression, UnaryExpression, Identifier
+from influxdb_client.client.util.date_utils import get_date_helper
 from tests.base_test import BaseTest
 
 
@@ -46,6 +50,195 @@ class SimpleQueryTest(BaseTest):
                 val_count += 1
 
         print("Values count: ", val_count)
+
+    def test_query_ast(self):
+        q = '''
+        from(bucket:stringParam) 
+            |> range(start: startDuration, stop: callParam)
+            |> filter(fn: (r) => r["_measurement"] == "my_measurement")
+            |> filter(fn: (r) => r["_value"] > intParam)
+            |> filter(fn: (r) => r["_value"] > floatParam)
+            |> aggregateWindow(every: durationParam, fn: mean, createEmpty: true)
+            |> sort(columns: ["_time"], desc: booleanParam) 
+        '''
+
+        p = {
+            "stringParam": "my-bucket",
+            "stopParam": get_date_helper().parse_date("2021-03-20T15:59:10.607352Z"),
+            "intParam": 2,
+            "durationParam": DurationLiteral("DurationLiteral", [Duration(magnitude=1, unit="d")]),
+            "startDuration": UnaryExpression(type="UnaryExpression",
+                                             argument=DurationLiteral("DurationLiteral",
+                                                                      [Duration(magnitude=30, unit="d")]),
+                                             operator="-"),
+            "callParam": CallExpression(type="CallExpression", callee=Identifier(type="Identifier", name="now")),
+            "timedelta": datetime.timedelta(minutes=10),
+            "floatParam": 14.01,
+            "booleanParam": True,
+        }
+
+        csv_result = self.client.query_api().query_csv(query=q, params=p)
+
+        self.assertIsNotNone(csv_result)
+
+        val_count = 0
+        for row in csv_result:
+            for cell in row:
+                val_count += 1
+
+        print("Values count: ", val_count)
+
+    def test_parameter_ast(self):
+        test_data = [["stringParam", "my-bucket", {
+            "imports": [],
+            "body": [
+                {
+                    "type": "OptionStatement",
+                    "assignment": {
+                        "type": "VariableAssignment",
+                        "id": {
+                            "type": "Identifier",
+                            "name": "stringParam"
+                        },
+                        "init": {
+                            "type": "StringLiteral",
+                            "value": "my-bucket"
+                        }
+                    }
+                }
+            ]
+        }], ["datetimeParam", get_date_helper().parse_date("2021-03-20T15:59:10.607352Z"), {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "datetimeParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "type": "DateTimeLiteral",
+                            "value": "2021-03-20T15:59:10.607352Z"
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
+        }], ["timeDeltaParam", datetime.timedelta(hours=1), {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "timeDeltaParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "type": "DurationLiteral",
+                            "values": [
+                                {
+                                    "magnitude": 3600000000,
+                                    "unit": "us"
+                                }
+                            ]
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
+        }], ["timeDeltaNegativeParam", datetime.timedelta(minutes=-5), {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "timeDeltaNegativeParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "argument": {
+                                "type": "DurationLiteral",
+                                "values": [
+                                    {
+                                        "magnitude": 300000000,
+                                        "unit": "us"
+                                    }
+                                ]
+                            },
+                            "operator": "-",
+                            "type": "UnaryExpression"
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
+        }], ["booleanParam", True, {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "booleanParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "type": "BooleanLiteral",
+                            "value": True
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
+        }], ["intParam", int(10), {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "intParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "type": "IntegerLiteral",
+                            "value": "10"
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
+        }], ["floatParam", 10.333,
+             {
+                 "body": [
+                     {
+                         "assignment": {
+                             "id": {
+                                 "name": "floatParam",
+                                 "type": "Identifier"
+                             },
+                             "init": {
+                                 "type": "FloatLiteral",
+                                 "value": 10.333
+                             },
+                             "type": "VariableAssignment"
+                         },
+                         "type": "OptionStatement"
+                     }
+                 ],
+                 "imports": []
+             }]]
+
+        for data in test_data:
+            param = {data[0]: data[1]}
+            print("testing: ", param)
+            ast = QueryApi._build_flux_ast(param)
+            got_sanitized = self.client.api_client.sanitize_for_serialization(ast)
+            self.assertEqual(json.dumps(got_sanitized, sort_keys=True, indent=2),
+                             json.dumps(data[2], sort_keys=True, indent=2))
 
 
 if __name__ == '__main__':

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -125,6 +125,24 @@ class SimpleQueryTest(BaseTest):
                 }
             ],
             "imports": []
+        }], ["datetimeNoTZParam", datetime.datetime(2021, 3, 20, 15, 59, 10, 607352), {
+            "body": [
+                {
+                    "assignment": {
+                        "id": {
+                            "name": "datetimeNoTZParam",
+                            "type": "Identifier"
+                        },
+                        "init": {
+                            "type": "DateTimeLiteral",
+                            "value": "2021-03-20T15:59:10.607352Z"
+                        },
+                        "type": "VariableAssignment"
+                    },
+                    "type": "OptionStatement"
+                }
+            ],
+            "imports": []
         }], ["timeDeltaParam", datetime.timedelta(hours=1), {
             "body": [
                 {


### PR DESCRIPTION
Closes #219 

Example of usage:
```python
p = {"_start": datetime.timedelta(hours=-1),
     "_location": "Prague",
     "_desc": True,
     "_floatParam": 25.1,
     "_every": datetime.timedelta(minutes=5)
     }

tables = query_api.query('''
    from(bucket:"my-bucket") |> range(start: _start)
        |> filter(fn: (r) => r["_measurement"] == "my_measurement")
        |> filter(fn: (r) => r["_field"] == "temperature")
        |> filter(fn: (r) => r["location"] == _location and r["_value"] > _floatParam)
        |> aggregateWindow(every: _every, fn: mean, createEmpty: true)        
        |> sort(columns: ["_time"], desc: _desc) 
''', params=p)
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
