### PR TITLE
fix: pass configured timeout to HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/issues/219): Bind query parameters 
 
+### Bug Fixes
+1. [#222](https://github.com/influxdata/influxdb-client-python/pull/222): Pass configured timeout to HTTP client
+
 ## 1.16.0 [2021-04-01]
 
 ### Features
@@ -11,7 +14,7 @@
 
 ### Bug Fixes
 1. [#206](https://github.com/influxdata/influxdb-client-python/pull/207): Use default (system) certificates instead of Mozilla's root certificates (certifi.where())
-1. [#217](https://github.com/influxdata/influxdb-client-python/pull/217): Fixed clone_task function
+1. [#217](https://github.com/influxdata/influxdb-client-python/pull/217): Fix clone_task function
 
 ### API
 1. [#209](https://github.com/influxdata/influxdb-client-python/pull/209): Allow setting shard-group durations for buckets via API

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -20,7 +20,7 @@ from influxdb_client.client.write_api import WriteApi, WriteOptions, PointSettin
 class InfluxDBClient(object):
     """InfluxDBClient is client for InfluxDB v2."""
 
-    def __init__(self, url, token, debug=None, timeout=10000, enable_gzip=False, org: str = None,
+    def __init__(self, url, token, debug=None, timeout=10_000, enable_gzip=False, org: str = None,
                  default_tags: dict = None, **kwargs) -> None:
         """
         Initialize defaults.
@@ -28,7 +28,9 @@ class InfluxDBClient(object):
         :param url: InfluxDB server API url (ex. http://localhost:8086).
         :param token: auth token
         :param debug: enable verbose logging of http requests
-        :param timeout: default http client timeout
+        :param timeout: HTTP client timeout setting for a request specified in milliseconds.
+                        If one number provided, it will be total request timeout.
+                        It can also be a pair (tuple) of (connection, read) timeouts.
         :param enable_gzip: Enable Gzip compression for http requests. Currently only the "Write" and "Query" endpoints
                             supports the Gzip compression.
         :param org: organization name (used as a default in query and write API)
@@ -43,7 +45,6 @@ class InfluxDBClient(object):
         """
         self.url = url
         self.token = token
-        self.timeout = timeout
         self.org = org
 
         self.default_tags = default_tags
@@ -59,6 +60,7 @@ class InfluxDBClient(object):
         conf.ssl_ca_cert = kwargs.get('ssl_ca_cert', None)
         conf.proxy = kwargs.get('proxy', None)
         conf.connection_pool_maxsize = kwargs.get('connection_pool_maxsize', conf.connection_pool_maxsize)
+        conf.timeout = timeout
 
         auth_token = self.token
         auth_header_name = "Authorization"

--- a/influxdb_client/configuration.py
+++ b/influxdb_client/configuration.py
@@ -103,6 +103,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         # requests to the same host, which is often the case here.
         # cpu_count * 5 is used as default value to increase performance.
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        # Timeout setting for a request. If one number provided, it will be total request timeout.
+        # It can also be a pair (tuple) of (connection, read) timeouts.
+        self.timeout = None
 
         # Proxy URL
         self.proxy = None

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -156,13 +156,14 @@ class RESTClientObject(object):
         headers = headers or {}
 
         timeout = None
-        if _request_timeout:
-            if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
-                timeout = urllib3.Timeout(total=_request_timeout)
-            elif (isinstance(_request_timeout, tuple) and
-                  len(_request_timeout) == 2):
+        _configured_timeout = _request_timeout or self.configuration.timeout
+        if _configured_timeout:
+            if isinstance(_configured_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+                timeout = urllib3.Timeout(total=_configured_timeout / 1_000)
+            elif (isinstance(_configured_timeout, tuple) and
+                  len(_configured_timeout) == 2):
                 timeout = urllib3.Timeout(
-                    connect=_request_timeout[0], read=_request_timeout[1])
+                    connect=_configured_timeout[0] / 1_000, read=_configured_timeout[1] / 1_000)
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -65,7 +65,7 @@ class InfluxDBClientTest(unittest.TestCase):
         self.assertEqual("http://localhost:8086", self.client.url)
         self.assertEqual("my-org", self.client.org)
         self.assertEqual("my-token", self.client.token)
-        self.assertEqual(6000, self.client.timeout)
+        self.assertEqual(6000, self.client.api_client.configuration.timeout)
         self.assertEqual(3, len(self.client.default_tags))
         self.assertEqual("132-987-655", self.client.default_tags["id"])
         self.assertEqual("California Miner", self.client.default_tags["customer"])

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -795,7 +795,7 @@ class DefaultTagsConfiguration(BaseTest):
 
         self.assertEqual("my-org", self.client.org)
         self.assertEqual("my-token", self.client.token)
-        self.assertEqual(6000, self.client.timeout)
+        self.assertEqual(6000, self.client.api_client.configuration.timeout)
 
     def test_default_tags_from_conf_file(self):
         self.client.close()


### PR DESCRIPTION
Closes #221

## Proposed Changes

Correctly pass configured timeout into `urllib3`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
