### PR TITLE
feat: implement exponential random retry strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/issues/219): Bind query parameters 
+1. [#225](https://github.com/influxdata/influxdb-client-python/pull/225): Exponential random backoff retry strategy 
 
 ### Bug Fixes
 1. [#222](https://github.com/influxdata/influxdb-client-python/pull/222): Pass configured timeout to HTTP client

--- a/README.rst
+++ b/README.rst
@@ -265,7 +265,7 @@ The batching is configurable by ``write_options``\ :
      - the maximum delay between each retry attempt in milliseconds
      - ``180_000``
    * - **exponential_base**
-     - the base for the exponential retry delay, the next delay is computed as ``retry_interval * exponential_base^(attempts-1) + random(jitter_interval)``
+     - the base for the exponential retry delay, the next delay is computed using Full Jitter formula ``retry_interval * exponential_base^(attempts-1) * random()``
      - ``5``
 
 

--- a/README.rst
+++ b/README.rst
@@ -263,12 +263,12 @@ The batching is configurable by ``write_options``\ :
      - ``180_000``
    * - **max_retries**
      - the number of max retries when write fails
-     - ``10``
+     - ``5``
    * - **max_retry_delay**
      - the maximum delay between each retry attempt in milliseconds
      - ``125_000``
    * - **exponential_base**
-     - the base for the exponential retry delay, the next delay is computed using random exponential backoff. Example for ``retry_interval=5_000, exponential_base=2, max_retry_delay=125_000, total=5`` Retry delays are random distributed values within the ranges of ``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``
+     - the base for the exponential retry delay, the next delay is computed using random exponential backoff as a random value within the interval  ``retry_interval * exponential_base^(attempts-1)`` and ``retry_interval * exponential_base^(attempts)``. Example for ``retry_interval=5_000, exponential_base=2, max_retry_delay=125_000, total=5`` Retry delays are random distributed values within the ranges of ``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``
      - ``2``
 
 

--- a/README.rst
+++ b/README.rst
@@ -259,7 +259,7 @@ The batching is configurable by ``write_options``\ :
      - the number of milliseconds to retry first unsuccessful write. The next retry delay is computed using exponential random backoff. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
      - ``5000``
    * - **max_retry_time**
-     - maximum total retry timout in milliseconds.
+     - maximum total retry timeout in milliseconds.
      - ``180_000``
    * - **max_retries**
      - the number of max retries when write fails

--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,7 @@ The batching is configurable by ``write_options``\ :
      - the number of milliseconds to increase the batch flush interval by a random amount
      - ``0``
    * - **retry_interval**
-     - the number of milliseconds to retry first unsuccessful write. The next retry delay is computed using Full Jitter formula. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
+     - the number of milliseconds to retry first unsuccessful write. The next retry delay is computed using exponential random backoff. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
      - ``5000``
    * - **max_retry_time**
      - maximum total retry timout in milliseconds.
@@ -266,12 +266,9 @@ The batching is configurable by ``write_options``\ :
      - ``10``
    * - **max_retry_delay**
      - the maximum delay between each retry attempt in milliseconds
-     - ``150_000``
-   * - **min_retry_delay**
-     - the minimum delay between each retry attempt in milliseconds
-     - ``1_000``
+     - ``125_000``
    * - **exponential_base**
-     - the base for the exponential retry delay, the next delay is computed using Full Jitter formula ``retry_interval * exponential_base^(attempts-1) * random()``
+     - the base for the exponential retry delay, the next delay is computed using random exponential backoff. Example for ``retry_interval=5_000, exponential_base=2, max_retry_delay=125_000, total=5`` Retry delays are random distributed values within the ranges of ``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``
      - ``2``
 
 

--- a/README.rst
+++ b/README.rst
@@ -256,17 +256,23 @@ The batching is configurable by ``write_options``\ :
      - the number of milliseconds to increase the batch flush interval by a random amount
      - ``0``
    * - **retry_interval**
-     - the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
+     - the number of milliseconds to retry first unsuccessful write. The next retry delay is computed using Full Jitter formula. The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
      - ``5000``
+   * - **max_retry_time**
+     - maximum total retry timout in milliseconds.
+     - ``180_000``
    * - **max_retries**
      - the number of max retries when write fails
-     - ``3``
+     - ``10``
    * - **max_retry_delay**
      - the maximum delay between each retry attempt in milliseconds
-     - ``180_000``
+     - ``150_000``
+   * - **min_retry_delay**
+     - the minimum delay between each retry attempt in milliseconds
+     - ``1_000``
    * - **exponential_base**
      - the base for the exponential retry delay, the next delay is computed using Full Jitter formula ``retry_interval * exponential_base^(attempts-1) * random()``
-     - ``5``
+     - ``2``
 
 
 .. code-block:: python

--- a/examples/import_data_set_sync_batching.py
+++ b/examples/import_data_set_sync_batching.py
@@ -30,7 +30,7 @@ def csv_to_generator(csv_file_path):
 """
 Define Retry strategy - 3 attempts => 2, 4, 8
 """
-retries = WritesRetry(total=3, backoff_factor=1, exponential_base=2)
+retries = WritesRetry(total=3, retry_interval=1, exponential_base=2)
 with InfluxDBClient(url='http://localhost:8086', token='my-token', org='my-org', retries=retries) as client:
 
     """

--- a/influxdb_client/client/write/retry.py
+++ b/influxdb_client/client/write/retry.py
@@ -15,23 +15,19 @@ class WritesRetry(Retry):
     """
     Writes retry configuration.
 
-    :param int jitter_interval: random milliseconds when retrying writes
     :param int max_retry_delay: maximum delay when retrying write
     :param int exponential_base: base for the exponential retry delay, the next delay is computed as
-                                 `backoff_factor * exponential_base^(attempts-1) + random(jitter_interval)`
+                                 `backoff_factor * exponential_base^(attempts-1) * random()`
     """
 
-    def __init__(self, jitter_interval=0, max_retry_delay=180, exponential_base=5, **kw):
+    def __init__(self, max_retry_delay=180, exponential_base=5, **kw):
         """Initialize defaults."""
         super().__init__(**kw)
-        self.jitter_interval = jitter_interval
         self.max_retry_delay = max_retry_delay
         self.exponential_base = exponential_base
 
     def new(self, **kw):
         """Initialize defaults."""
-        if 'jitter_interval' not in kw:
-            kw['jitter_interval'] = self.jitter_interval
         if 'max_retry_delay' not in kw:
             kw['max_retry_delay'] = self.max_retry_delay
         if 'exponential_base' not in kw:
@@ -58,15 +54,9 @@ class WritesRetry(Retry):
         if consecutive_errors_len < 0:
             return 0
 
-        backoff_value = self.backoff_factor * (self.exponential_base ** consecutive_errors_len) + self._jitter_delay()
+        # Full Jitter strategy
+        backoff_value = self.backoff_factor * (self.exponential_base ** consecutive_errors_len) * self._random()
         return min(self.max_retry_delay, backoff_value)
-
-    def get_retry_after(self, response):
-        """Get the value of Retry-After header and append random jitter delay."""
-        retry_after = super().get_retry_after(response)
-        if retry_after:
-            retry_after += self._jitter_delay()
-        return retry_after
 
     def increment(self, method=None, url=None, response=None, error=None, _pool=None, _stacktrace=None):
         """Return a new Retry object with incremented retry counters."""
@@ -87,5 +77,5 @@ class WritesRetry(Retry):
 
         return new_retry
 
-    def _jitter_delay(self):
-        return self.jitter_interval * random()
+    def _random(self):
+        return random()

--- a/influxdb_client/client/write/retry.py
+++ b/influxdb_client/client/write/retry.py
@@ -84,7 +84,7 @@ class WritesRetry(Retry):
             if delay_range > self.max_retry_delay:
                 break
 
-        delay = delay_range * self._random()
+        delay = self.min_retry_delay + (delay_range - self.min_retry_delay) * self._random()
         # at least min_retry_delay
         delay = max(self.min_retry_delay, delay)
         # at most max_retry_delay

--- a/influxdb_client/client/write/retry.py
+++ b/influxdb_client/client/write/retry.py
@@ -17,7 +17,7 @@ class WritesRetry(Retry):
     """
     Writes retry configuration.
 
-    :param int max_retry_time: maximum total retry timout in seconds, attempt after this timout throws MaxRetryError
+    :param int max_retry_time: maximum total retry timeout in seconds, attempt after this timout throws MaxRetryError
     :param int total: maximum number of retries
     :param num retry_interval: initial first retry delay range in seconds
     :param num max_retry_delay: maximum delay when retrying write in seconds

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -39,8 +39,7 @@ class WriteOptions(object):
                  jitter_interval=0,
                  retry_interval=5_000,
                  max_retries=10,
-                 max_retry_delay=150_000,
-                 min_retry_delay=1_000,
+                 max_retry_delay=125_000,
                  max_retry_time=180_000,
                  exponential_base=2,
                  write_scheduler=ThreadPoolScheduler(max_workers=1)) -> None:
@@ -55,10 +54,8 @@ class WriteOptions(object):
         :param retry_interval: the time to wait before retry unsuccessful write
         :param max_retries: the number of max retries when write fails, 0 means retry is disabled
         :param max_retry_delay: the maximum delay between each retry attempt in milliseconds
-        :param min_retry_delay: the minimum delay between each retry attempt in milliseconds
         :param max_retry_time: total timeout for all retry attempts in milliseconds, if 0 retry is disabled
-        :param exponential_base: base for the exponential retry delay, the next delay is computed as
-                                 `retry_interval * exponential_base^(attempts-1) + random(jitter_interval)`
+        :param exponential_base: base for the exponential retry delay
         :param write_scheduler:
         """
         self.write_type = write_type
@@ -68,7 +65,6 @@ class WriteOptions(object):
         self.retry_interval = retry_interval
         self.max_retries = max_retries
         self.max_retry_delay = max_retry_delay
-        self.min_retry_delay = min_retry_delay
         self.max_retry_time = max_retry_time
         self.exponential_base = exponential_base
         self.write_scheduler = write_scheduler
@@ -79,7 +75,6 @@ class WriteOptions(object):
             total=self.max_retries,
             backoff_factor=self.retry_interval / 1_000,
             max_retry_delay=self.max_retry_delay / 1_000,
-            min_retry_delay=self.min_retry_delay / 1_000,
             max_retry_time=self.max_retry_time / 1000,
             exponential_base=self.exponential_base,
             allowed_methods=["POST"])

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -364,7 +364,6 @@ class WriteApi:
         retry = WritesRetry(
             total=self._write_options.max_retries,
             backoff_factor=self._write_options.retry_interval / 1_000,
-            jitter_interval=self._write_options.jitter_interval / 1_000,
             max_retry_delay=self._write_options.max_retry_delay / 1_000,
             method_whitelist=["POST"])
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -72,7 +72,6 @@ class WriteOptions(object):
         return WritesRetry(
             total=self.max_retries,
             backoff_factor=self.retry_interval / 1_000,
-            jitter_interval=self.jitter_interval / 1_000,
             max_retry_delay=self.max_retry_delay / 1_000,
             exponential_base=self.exponential_base,
             method_whitelist=["POST"])

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -38,7 +38,7 @@ class WriteOptions(object):
                  batch_size=1_000, flush_interval=1_000,
                  jitter_interval=0,
                  retry_interval=5_000,
-                 max_retries=10,
+                 max_retries=5,
                  max_retry_delay=125_000,
                  max_retry_time=180_000,
                  exponential_base=2,
@@ -73,9 +73,9 @@ class WriteOptions(object):
         """Create a Retry strategy from write options."""
         return WritesRetry(
             total=self.max_retries,
-            backoff_factor=self.retry_interval / 1_000,
+            retry_interval=self.retry_interval / 1_000,
             max_retry_delay=self.max_retry_delay / 1_000,
-            max_retry_time=self.max_retry_time / 1000,
+            max_retry_time=self.max_retry_time / 1_000,
             exponential_base=self.exponential_base,
             allowed_methods=["POST"])
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -77,7 +77,7 @@ class WriteOptions(object):
             max_retry_delay=self.max_retry_delay / 1_000,
             max_retry_time=self.max_retry_time / 1_000,
             exponential_base=self.exponential_base,
-            allowed_methods=["POST"])
+            method_whitelist=["POST"])
 
     def __getstate__(self):
         """Return a dict of attributes that you want to pickle."""

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -74,6 +74,7 @@ class WriteOptions(object):
         return WritesRetry(
             total=self.max_retries,
             retry_interval=self.retry_interval / 1_000,
+            jitter_interval=self.jitter_interval / 1_000,
             max_retry_delay=self.max_retry_delay / 1_000,
             max_retry_time=self.max_retry_time / 1_000,
             exponential_base=self.exponential_base,

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -361,11 +361,7 @@ class WriteApi:
 
         logger.debug("Write time series data into InfluxDB: %s", batch_item)
 
-        retry = WritesRetry(
-            total=self._write_options.max_retries,
-            backoff_factor=self._write_options.retry_interval / 1_000,
-            max_retry_delay=self._write_options.max_retry_delay / 1_000,
-            method_whitelist=["POST"])
+        retry = self._write_options.to_retry_strategy()
 
         self._post_write(False, batch_item.key.bucket, batch_item.key.org, batch_item.data,
                          batch_item.key.precision, urlopen_kw={'retries': retry})

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -198,7 +198,7 @@ class BatchingWriteTest(unittest.TestCase):
         time.sleep(1)
         self.assertEqual(1, len(httpretty.httpretty.latest_requests), msg="first request immediately")
 
-        time.sleep(1.5)
+        time.sleep(3)
         self.assertEqual(2, len(httpretty.httpretty.latest_requests), msg="second request after delay_interval")
 
         time.sleep(3)
@@ -266,7 +266,7 @@ class BatchingWriteTest(unittest.TestCase):
                                  ["h2o_feet,location=coyote_creek level\\ water_level=1 1",
                                   "h2o_feet,location=coyote_creek level\\ water_level=2 2"])
 
-        time.sleep(2)
+        time.sleep(5)
 
         self.assertEqual(1, len(httpretty.httpretty.latest_requests))
 

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -238,6 +238,38 @@ class BatchingWriteTest(unittest.TestCase):
 
         self.assertEqual(6, len(httpretty.httpretty.latest_requests))
 
+    def test_retry_disabled_max_retries(self):
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=429,
+                               adding_headers={'Retry-After': '1'})
+
+        self._write_client.close()
+        self._write_client = WriteApi(influxdb_client=self.influxdb_client,
+                                      write_options=WriteOptions(max_retries=0,batch_size=2, flush_interval=1_000))
+
+        self._write_client.write("my-bucket", "my-org",
+                                 ["h2o_feet,location=coyote_creek level\\ water_level=1 1",
+                                  "h2o_feet,location=coyote_creek level\\ water_level=2 2"])
+
+        time.sleep(2)
+
+        self.assertEqual(1, len(httpretty.httpretty.latest_requests))
+
+    def test_retry_disabled_max_retry_time(self):
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=429,
+                               adding_headers={'Retry-After': '1'})
+
+        self._write_client.close()
+        self._write_client = WriteApi(influxdb_client=self.influxdb_client,
+                                      write_options=WriteOptions(max_retry_time=0,batch_size=2, flush_interval=1_000))
+
+        self._write_client.write("my-bucket", "my-org",
+                                 ["h2o_feet,location=coyote_creek level\\ water_level=1 1",
+                                  "h2o_feet,location=coyote_creek level\\ water_level=2 2"])
+
+        time.sleep(2)
+
+        self.assertEqual(1, len(httpretty.httpretty.latest_requests))
+
     def test_recover_from_error(self):
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=400)

--- a/tests/test_WriteOptions.py
+++ b/tests/test_WriteOptions.py
@@ -7,8 +7,8 @@ class TestWriteOptions(unittest.TestCase):
     def test_default(self):
         retry = WriteOptions().to_retry_strategy()
 
-        self.assertEqual(retry.total, 10)
-        self.assertEqual(retry.backoff_factor, 5)
+        self.assertEqual(retry.total, 5)
+        self.assertEqual(retry.retry_interval, 5)
         self.assertEqual(retry.max_retry_time, 180)
         self.assertEqual(retry.max_retry_delay, 125)
         self.assertEqual(retry.exponential_base, 2)
@@ -21,7 +21,7 @@ class TestWriteOptions(unittest.TestCase):
             .to_retry_strategy()
 
         self.assertEqual(retry.total, 5)
-        self.assertEqual(retry.backoff_factor, 0.5)
+        self.assertEqual(retry.retry_interval, 0.5)
         self.assertEqual(retry.max_retry_delay, 7.5)
         self.assertEqual(retry.exponential_base, 2)
         self.assertEqual(retry.method_whitelist, ["POST"])

--- a/tests/test_WriteOptions.py
+++ b/tests/test_WriteOptions.py
@@ -7,10 +7,11 @@ class TestWriteOptions(unittest.TestCase):
     def test_default(self):
         retry = WriteOptions().to_retry_strategy()
 
-        self.assertEqual(retry.total, 3)
+        self.assertEqual(retry.total, 10)
         self.assertEqual(retry.backoff_factor, 5)
-        self.assertEqual(retry.max_retry_delay, 180)
-        self.assertEqual(retry.exponential_base, 5)
+        self.assertEqual(retry.max_retry_time, 180)
+        self.assertEqual(retry.max_retry_delay, 150)
+        self.assertEqual(retry.exponential_base, 2)
         self.assertEqual(retry.method_whitelist, ["POST"])
 
     def test_custom(self):

--- a/tests/test_WriteOptions.py
+++ b/tests/test_WriteOptions.py
@@ -9,7 +9,6 @@ class TestWriteOptions(unittest.TestCase):
 
         self.assertEqual(retry.total, 3)
         self.assertEqual(retry.backoff_factor, 5)
-        self.assertEqual(retry.jitter_interval, 0)
         self.assertEqual(retry.max_retry_delay, 180)
         self.assertEqual(retry.exponential_base, 5)
         self.assertEqual(retry.method_whitelist, ["POST"])
@@ -22,7 +21,6 @@ class TestWriteOptions(unittest.TestCase):
 
         self.assertEqual(retry.total, 5)
         self.assertEqual(retry.backoff_factor, 0.5)
-        self.assertEqual(retry.jitter_interval, 2)
         self.assertEqual(retry.max_retry_delay, 7.5)
         self.assertEqual(retry.exponential_base, 2)
         self.assertEqual(retry.method_whitelist, ["POST"])

--- a/tests/test_WriteOptions.py
+++ b/tests/test_WriteOptions.py
@@ -10,7 +10,7 @@ class TestWriteOptions(unittest.TestCase):
         self.assertEqual(retry.total, 10)
         self.assertEqual(retry.backoff_factor, 5)
         self.assertEqual(retry.max_retry_time, 180)
-        self.assertEqual(retry.max_retry_delay, 150)
+        self.assertEqual(retry.max_retry_delay, 125)
         self.assertEqual(retry.exponential_base, 2)
         self.assertEqual(retry.method_whitelist, ["POST"])
 

--- a/tests/test_WritesRetry.py
+++ b/tests/test_WritesRetry.py
@@ -143,15 +143,15 @@ class TestWritesRetry(unittest.TestCase):
 
         self.assertLessEqual(retry.get_backoff_time(), 15)
 
-    def test_backoff_jitter(self):
-        retry = WritesRetry(total=5, retry_interval=4, jitter_interval=2).increment()
+    def test_backoff_increment(self):
+        retry = WritesRetry(total=5, retry_interval=4).increment()
 
         self.assertEqual(retry.total, 4)
         self.assertEqual(retry.is_exhausted(), False)
 
         backoff_time = retry.get_backoff_time()
         self.assertGreater(backoff_time, 4)
-        self.assertLessEqual(backoff_time, 6)
+        self.assertLessEqual(backoff_time, 8)
 
     def test_backoff_exponential_base(self):
         retry = NonRandomMinWritesRetry(total=5, retry_interval=2, exponential_base=2)

--- a/tests/test_WritesRetry.py
+++ b/tests/test_WritesRetry.py
@@ -57,7 +57,7 @@ class TestWritesRetry(unittest.TestCase):
         self.assertEqual("max_retry_time exceeded", exception.reason.args[0])
 
     def test_backoff_start_range(self):
-        retry = NonRandomMinWritesRetry(total=5, backoff_factor=1, exponential_base=2,
+        retry = NonRandomMinWritesRetry(total=5, retry_interval=1, exponential_base=2,
                                         max_retry_delay=550)
         self.assertEqual(retry.total, 5)
         self.assertEqual(retry.is_exhausted(), False)
@@ -95,7 +95,7 @@ class TestWritesRetry(unittest.TestCase):
         self.assertEqual("too many error responses", exception.reason.args[0])
 
     def test_backoff_stop_range(self):
-        retry = NonRandomMaxWritesRetry(total=5, backoff_factor=5, exponential_base=2,
+        retry = NonRandomMaxWritesRetry(total=5, retry_interval=5, exponential_base=2,
                                         max_retry_delay=550)
 
         self.assertEqual(retry.total, 5)
@@ -134,7 +134,7 @@ class TestWritesRetry(unittest.TestCase):
         self.assertEqual("too many error responses", exception.reason.args[0])
 
     def test_backoff_max(self):
-        retry = WritesRetry(total=5, backoff_factor=1, max_retry_delay=15) \
+        retry = WritesRetry(total=5, retry_interval=1, max_retry_delay=15) \
             .increment() \
             .increment() \
             .increment() \
@@ -144,7 +144,7 @@ class TestWritesRetry(unittest.TestCase):
         self.assertLessEqual(retry.get_backoff_time(), 15)
 
     def test_backoff_jitter(self):
-        retry = WritesRetry(total=5, backoff_factor=4).increment()
+        retry = WritesRetry(total=5, retry_interval=4).increment()
 
         self.assertEqual(retry.total, 4)
         self.assertEqual(retry.is_exhausted(), False)
@@ -153,7 +153,7 @@ class TestWritesRetry(unittest.TestCase):
         self.assertLessEqual(backoff_time, 8)
 
     def test_backoff_exponential_base(self):
-        retry = NonRandomMinWritesRetry(total=5, backoff_factor=2, exponential_base=2)
+        retry = NonRandomMinWritesRetry(total=5, retry_interval=2, exponential_base=2)
 
         retry = retry.increment()
         self.assertEqual(retry.get_backoff_time(), 2)
@@ -205,7 +205,7 @@ class TestWritesRetry(unittest.TestCase):
         response.headers.add('Retry-After', '63')
 
         with self.assertLogs('influxdb_client.client.write.retry', level='WARNING') as cm:
-            WritesRetry(total=5, backoff_factor=1, max_retry_delay=15) \
+            WritesRetry(total=5, retry_interval=1, max_retry_delay=15) \
                 .increment(response=response) \
                 .increment(error=Exception("too many requests")) \
                 .increment(url='http://localhost:9999')


### PR DESCRIPTION
## Proposed Changes

This PR changes the default retry strategy to Full Jitter. 

Related discussion is https://github.com/influxdata/influxdb/pull/19722#discussion_r518796754

Original retry formula:
`retry_interval * exponential_base^(attempts-1) + random(jitter_interval)`

Purposed exponential random retry formula:

Retry delay is calculated as random value within the interval  
[`retry_interval * exponential_base^(attempts-1) and
 retry_interval * exponential_base^(attempts)`]

Example for ``retry_interval=5_000, exponential_base=2, max_retry_delay=125_000`` 

Retry delays are random distributed values within the ranges of 
``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
