### PR TITLE
fix: write a dictionary-style object without tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [#222](https://github.com/influxdata/influxdb-client-python/pull/222): Pass configured timeout to HTTP client
 1. [#218](https://github.com/influxdata/influxdb-client-python/pull/218): Support for `with .. as ..` statement
 1. [#232](https://github.com/influxdata/influxdb-client-python/pull/232): Specify package requirements in `setup.py`
+1. [#235](https://github.com/influxdata/influxdb-client-python/pull/235): Write a dictionary-style object without tags
 
 ## 1.16.0 [2021-04-01]
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -353,6 +353,7 @@ class WriteApi:
         elif isinstance(record, Point):
             record.tag(key, val)
         elif isinstance(record, dict):
+            record.setdefault("tags", {})
             record.get("tags")[key] = val
         elif isinstance(record, Iterable):
             for item in record:

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -502,6 +502,19 @@ class WriteApiTestMock(BaseTest):
         self.assertEqual("Service Unavailable", exception.reason)
         self.assertEqual(1, len(httpretty.httpretty.latest_requests))
 
+    def test_writes_default_tags_dict_without_tag(self):
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
+
+        point_settings = PointSettings(**{"id": "132-987-655", "customer": "California Miner"})
+        self.write_client = self.influxdb_client.write_api(write_options=SYNCHRONOUS,
+                                                           point_settings=point_settings)
+
+        self.write_client.write("my-bucket", "my-org", {"measurement": "h2o", "fields": {"level": 1.0}, "time": 1})
+
+        requests = httpretty.httpretty.latest_requests
+        self.assertEqual(1, len(requests))
+        self.assertEqual("h2o,customer=California\\ Miner,id=132-987-655 level=1 1", requests[0].parsed_body)
+
 
 class AsynchronousWriteTest(BaseTest):
 


### PR DESCRIPTION
Closes #234 

## Proposed Changes

Added a default empty dict for `tags` in dictionary-style object.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
