### PR TITLE
feat: add possibility to specify default `timezone` for datetimes without `tzinfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ### Features
 1. [#237](https://github.com/influxdata/influxdb-client-python/pull/237): Use kwargs to pass query parameters into API list call - useful for the ability to use pagination.
 1. [#241](https://github.com/influxdata/influxdb-client-python/pull/241): Add detail error message for not supported type of `Point.field`
+1. [#238](https://github.com/influxdata/influxdb-client-python/pull/238): Add possibility to specify default `timezone` for datetimes without `tzinfo`
 
 ## 1.17.0 [2021-04-30]
 
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/issues/219): Bind query parameters 
 1. [#225](https://github.com/influxdata/influxdb-client-python/pull/225): Exponential random backoff retry strategy 
-1. [#238](https://github.com/influxdata/influxdb-client-python/pull/238): Add possibility to specify default `timezone` for datetimes without `tzinfo` 
 
 ### Bug Fixes
 1. [#222](https://github.com/influxdata/influxdb-client-python/pull/222): Pass configured timeout to HTTP client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 1. [#203](https://github.com/influxdata/influxdb-client-python/issues/219): Bind query parameters 
 1. [#225](https://github.com/influxdata/influxdb-client-python/pull/225): Exponential random backoff retry strategy 
+1. [#238](https://github.com/influxdata/influxdb-client-python/pull/238): Add possibility to specify default `timezone` for datetimes without `tzinfo` 
 
 ### Bug Fixes
 1. [#222](https://github.com/influxdata/influxdb-client-python/pull/222): Pass configured timeout to HTTP client

--- a/influxdb_client/client/util/date_utils.py
+++ b/influxdb_client/client/util/date_utils.py
@@ -10,6 +10,15 @@ date_helper = None
 class DateHelper:
     """DateHelper to groups different implementations of date operations."""
 
+    def __init__(self, timezone: datetime.tzinfo = UTC) -> None:
+        """
+        Initialize defaults.
+
+        :param timezone: Default timezone used for serialization "datetime" without "tzinfo".
+                         Default value is "UTC".
+        """
+        self.timezone = timezone
+
     def parse_date(self, date_string: str):
         """
         Parse string into Date or Timestamp.
@@ -40,7 +49,7 @@ class DateHelper:
         :return: datetime in UTC
         """
         if not value.tzinfo:
-            return UTC.localize(value)
+            return self.to_utc(value.replace(tzinfo=self.timezone))
         else:
             return value.astimezone(UTC)
 

--- a/tests/test_DateHelper.py
+++ b/tests/test_DateHelper.py
@@ -5,22 +5,17 @@ from datetime import datetime, timezone
 
 from pytz import UTC, timezone
 
-from influxdb_client.client.util import date_utils
-from influxdb_client.client.util.date_utils import DateHelper, get_date_helper
+from influxdb_client.client.util.date_utils import DateHelper
 
 
 class DateHelperTest(unittest.TestCase):
 
-    def setUp(self) -> None:
-        date_utils.date_helper = DateHelper()
-
     def test_to_utc(self):
-        date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        date = DateHelper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
         self.assertEqual(datetime(2021, 4, 29, 20, 30, 10, 0, UTC), date)
 
     def test_to_utc_different_timezone(self):
-        date_utils.date_helper = DateHelper(timezone=timezone('ETC/GMT+2'))
-        date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        date = DateHelper(timezone=timezone('ETC/GMT+2')).to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
         self.assertEqual(datetime(2021, 4, 29, 22, 30, 10, 0, UTC), date)
 
 

--- a/tests/test_DateHelper.py
+++ b/tests/test_DateHelper.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from datetime import datetime, timezone
+
+from pytz import UTC, timezone
+
+from influxdb_client.client.util import date_utils
+from influxdb_client.client.util.date_utils import DateHelper, get_date_helper
+
+
+class DateHelperTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        date_utils.date_helper = DateHelper()
+
+    def test_to_utc(self):
+        date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        self.assertEqual(datetime(2021, 4, 29, 20, 30, 10, 0, UTC), date)
+
+    def test_to_utc_different_timezone(self):
+        date_utils.date_helper = DateHelper(timezone=timezone('ETC/GMT+2'))
+        date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        self.assertEqual(datetime(2021, 4, 29, 22, 30, 10, 0, UTC), date)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #73

## Proposed Changes

Added possibility to specify default timezone for `datetime`s without `tzinfo`. 

It is useful for specify system timezone:

```python
from dateutil.tz import tzlocal

from influxdb_client.client.util import date_utils
from influxdb_client.client.util.date_utils import DateHelper

date_utils.date_helper = DateHelper(timezone=tzlocal())
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
