### PR TITLE
chore: add detail error message for not supported type of `Point.field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#237](https://github.com/influxdata/influxdb-client-python/pull/237): Use kwargs to pass query parameters into API list call - useful for the ability to use pagination.
+1. [#241](https://github.com/influxdata/influxdb-client-python/pull/241): Add detail error message for not supported type of `Point.field`
 
 ## 1.17.0 [2021-04-30]
 

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -165,7 +165,7 @@ def _append_fields(fields):
         elif isinstance(value, str):
             _return.append(f'{_escape_key(field)}="{_escape_string(value)}"')
         else:
-            raise ValueError()
+            raise ValueError(f'Type: "{type(value)}" of field: "{field}" is not supported.')
 
     return f"{','.join(_return)}"
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -369,6 +369,16 @@ class PointTest(unittest.TestCase):
         point_hk = Point.measurement("h2o").field("val", 1).time(time_in_hk)
         self.assertEqual(point_utc.to_line_protocol(), point_hk.to_line_protocol())
 
+    def test_unsupported_field_type(self):
+        with self.assertRaises(ValueError) as ve:
+            Point.measurement("h2o") \
+                .tag("location", "europe") \
+                .field("level", UTC) \
+                .to_line_protocol()
+        exception = ve.exception
+
+        self.assertEqual('Type: "<class \'pytz.UTC\'>" of field: "level" is not supported.', f'{exception}')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #239

## Proposed Changes

Added detail error message for not supported type of `Point.field`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
