### PR TITLE
feat: Pass timeout to read and write queries

### DIFF
--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -146,8 +146,10 @@ class QueryApi(object):
         if org is None:
             org = self._influxdb_client.org
 
+        request_timeout = self._influxdb_client.api_client.configuration.timeout
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
-                                              async_req=False, _preload_content=False, _return_http_data_only=False)
+                                              async_req=False, _preload_content=False, _return_http_data_only=False,
+                                              _request_timeout=request_timeout)
 
         _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.dataFrame,
                                 data_frame_index=data_frame_index)

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -368,8 +368,9 @@ class WriteApi:
 
         retry = self._write_options.to_retry_strategy()
 
+        request_timeout = self._influxdb_client.api_client.configuration.timeout
         self._post_write(False, batch_item.key.bucket, batch_item.key.org, batch_item.data,
-                         batch_item.key.precision, urlopen_kw={'retries': retry})
+                         batch_item.key.precision, urlopen_kw={'retries': retry}, _request_timeout=request_timeout)
 
         logger.debug("Write request finished %s", batch_item)
 


### PR DESCRIPTION
Closes #

## Proposed Changes

Request timeout is passed to read and write calls. Not sure if this is the way you would implement it, but we really needed those so thought to share our current implementation in case you find it useful.

Kindest regards


