### PR TITLE
feat: config option to allow basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#237](https://github.com/influxdata/influxdb-client-python/pull/237): Use kwargs to pass query parameters into API list call - useful for the ability to use pagination.
 1. [#241](https://github.com/influxdata/influxdb-client-python/pull/241): Add detail error message for not supported type of `Point.field`
 1. [#238](https://github.com/influxdata/influxdb-client-python/pull/238): Add possibility to specify default `timezone` for datetimes without `tzinfo`
+1. [#262](https://github.com/influxdata/influxdb-client-python/issues/262): Add option `auth_basic` to allow proxied access to InfluxDB 1.8.x compatibility API
 
 ### Bug Fixes
 1. [#254](https://github.com/influxdata/influxdb-client-python/pull/254): Serialize `numpy` floats into LineProtocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#237](https://github.com/influxdata/influxdb-client-python/pull/237): Use kwargs to pass query parameters into API list call - useful for the ability to use pagination.
 1. [#241](https://github.com/influxdata/influxdb-client-python/pull/241): Add detail error message for not supported type of `Point.field`
 1. [#238](https://github.com/influxdata/influxdb-client-python/pull/238): Add possibility to specify default `timezone` for datetimes without `tzinfo`
-1. [#262](https://github.com/influxdata/influxdb-client-python/issues/262): Add option `auth_basic` to allow proxied access to InfluxDB 1.8.x compatibility API
+1. [#262](https://github.com/influxdata/influxdb-client-python/pull/263): Add option `auth_basic` to allow proxied access to InfluxDB 1.8.x compatibility API
 
 ### Bug Fixes
 1. [#254](https://github.com/influxdata/influxdb-client-python/pull/254): Serialize `numpy` floats into LineProtocol

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ The following options are supported:
 - ``verify_ssl`` - set this to false to skip verifying SSL certificate when calling API from https server
 - ``ssl_ca_cert`` - set this to customize the certificate file to verify the peer
 - ``connection_pool_maxsize`` - set the number of connections to save that can be reused by urllib3
+- ``auth_basic`` - enable http basic authentication when talking to a InfluxDB 1.8.x without authentication but is accessed via reverse proxy with basic authentication (defaults to false)
 
 .. code-block:: python
 
@@ -202,6 +203,7 @@ Supported properties are:
 - ``INFLUXDB_V2_VERIFY_SSL`` - set this to false to skip verifying SSL certificate when calling API from https server
 - ``INFLUXDB_V2_SSL_CA_CERT`` - set this to customize the certificate file to verify the peer
 - ``INFLUXDB_V2_CONNECTION_POOL_MAXSIZE`` - set the number of connections to save that can be reused by urllib3
+- ``INFLUXDB_V2_AUTH_BASIC`` - enable http basic authentication when talking to a InfluxDB 1.8.x without authentication but is accessed via reverse proxy with basic authentication (defaults to false)
 
 .. code-block:: python
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import
 
 import configparser
-import os, base64
+import os
+import base64
 
 from influxdb_client import Configuration, ApiClient, HealthCheck, HealthService, Ready, ReadyService
 from influxdb_client.client.authorizations_api import AuthorizationsApi
@@ -66,11 +67,9 @@ class InfluxDBClient(object):
         auth_header_name = "Authorization"
         auth_header_value = "Token " + auth_token
 
-        # allow basic authentication for cases where InfluxDB (backwards 1.8 doesn't use auth but proxies perform basic auth)
         auth_basic = kwargs.get('auth_basic', False)
         if auth_basic:
             auth_header_value = "Basic " + base64.b64encode(token.encode()).decode()
-
 
         retries = kwargs.get('retries', False)
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import configparser
-import os
+import os, base64
 
 from influxdb_client import Configuration, ApiClient, HealthCheck, HealthService, Ready, ReadyService
 from influxdb_client.client.authorizations_api import AuthorizationsApi
@@ -65,6 +65,12 @@ class InfluxDBClient(object):
         auth_token = self.token
         auth_header_name = "Authorization"
         auth_header_value = "Token " + auth_token
+
+        # allow basic authentication for cases where InfluxDB (backwards 1.8 doesn't use auth but proxies perform basic auth)
+        auth_basic = kwargs.get('auth_basic', False)
+        if auth_basic:
+            auth_header_value = "Basic " + base64.b64encode(token.encode()).decode()
+
 
         retries = kwargs.get('retries', False)
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -42,8 +42,8 @@ class InfluxDBClient(object):
                                           Defaults to "multiprocessing.cpu_count() * 5".
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
                                                except batching writes. As a default there is no one retry strategy.
-        :key bool auth_basic: Set this to true to enable basic authentication when talking to a InfluxDB 1.8.x that does not
-                              use auth-enabled but is protected by a reverse proxy with basic authentication.
+        :key bool auth_basic: Set this to true to enable basic authentication when talking to a InfluxDB 1.8.x that
+                              does not use auth-enabled but is protected by a reverse proxy with basic authentication.
                               (defaults to false, don't set to true when talking to InfluxDB 2)
         """
         self.url = url

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -42,7 +42,9 @@ class InfluxDBClient(object):
                                           Defaults to "multiprocessing.cpu_count() * 5".
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
                                                except batching writes. As a default there is no one retry strategy.
-
+        :key bool auth_basic: Set this to true to enable basic authentication when talking to a InfluxDB 1.8.x that does not
+                              use auth-enabled but is protected by a reverse proxy with basic authentication.
+                              (defaults to false, don't set to true when talking to InfluxDB 2)
         """
         self.url = url
         self.token = token
@@ -108,6 +110,7 @@ class InfluxDBClient(object):
             - verify_ssl
             - ssl_ca_cert
             - connection_pool_maxsize
+            - auth_basic
 
         config.ini example::
 
@@ -117,6 +120,7 @@ class InfluxDBClient(object):
             token=my-token
             timeout=6000
             connection_pool_maxsize=25
+            auth_basic=false
 
             [tags]
             id = 132-987-655
@@ -131,6 +135,7 @@ class InfluxDBClient(object):
                 org = "my-org"
                 timeout = 6000
                 connection_pool_maxsize = 25
+                auth_basic = false
 
             [tags]
                 id = "132-987-655"
@@ -148,12 +153,10 @@ class InfluxDBClient(object):
         token = config_value('token')
 
         timeout = None
-
         if config.has_option('influx2', 'timeout'):
             timeout = config_value('timeout')
 
         org = None
-
         if config.has_option('influx2', 'org'):
             org = config_value('org')
 
@@ -169,15 +172,18 @@ class InfluxDBClient(object):
         if config.has_option('influx2', 'connection_pool_maxsize'):
             connection_pool_maxsize = config_value('connection_pool_maxsize')
 
-        default_tags = None
+        auth_basic = False
+        if config.has_option('influx2', 'auth_basic'):
+            auth_basic = config_value('auth_basic')
 
+        default_tags = None
         if config.has_section('tags'):
             tags = {k: v.strip('"') for k, v in config.items('tags')}
             default_tags = dict(tags)
 
         return cls(url, token, debug=debug, timeout=_to_int(timeout), org=org, default_tags=default_tags,
                    enable_gzip=enable_gzip, verify_ssl=_to_bool(verify_ssl), ssl_ca_cert=ssl_ca_cert,
-                   connection_pool_maxsize=_to_int(connection_pool_maxsize))
+                   connection_pool_maxsize=_to_int(connection_pool_maxsize), auth_basic=_to_bool(auth_basic))
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False):
@@ -192,6 +198,7 @@ class InfluxDBClient(object):
             - INFLUXDB_V2_VERIFY_SSL
             - INFLUXDB_V2_SSL_CA_CERT
             - INFLUXDB_V2_CONNECTION_POOL_MAXSIZE
+            - INFLUXDB_V2_AUTH_BASIC
         """
         url = os.getenv('INFLUXDB_V2_URL', "http://localhost:8086")
         token = os.getenv('INFLUXDB_V2_TOKEN', "my-token")
@@ -200,6 +207,7 @@ class InfluxDBClient(object):
         verify_ssl = os.getenv('INFLUXDB_V2_VERIFY_SSL', "True")
         ssl_ca_cert = os.getenv('INFLUXDB_V2_SSL_CA_CERT', None)
         connection_pool_maxsize = os.getenv('INFLUXDB_V2_CONNECTION_POOL_MAXSIZE', None)
+        auth_basic = os.getenv('INFLUXDB_V2_AUTH_BASIC', "False")
 
         default_tags = dict()
 
@@ -209,7 +217,7 @@ class InfluxDBClient(object):
 
         return cls(url, token, debug=debug, timeout=_to_int(timeout), org=org, default_tags=default_tags,
                    enable_gzip=enable_gzip, verify_ssl=_to_bool(verify_ssl), ssl_ca_cert=ssl_ca_cert,
-                   connection_pool_maxsize=_to_int(connection_pool_maxsize))
+                   connection_pool_maxsize=_to_int(connection_pool_maxsize), auth_basic=_to_bool(auth_basic))
 
     def write_api(self, write_options=WriteOptions(), point_settings=PointSettings()) -> WriteApi:
         """

--- a/influxdb_client/configuration.py
+++ b/influxdb_client/configuration.py
@@ -107,6 +107,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         # It can also be a pair (tuple) of (connection, read) timeouts.
         self.timeout = None
 
+        # Set to True/False to enable basic authentication when using proxied InfluxDB 1.8.x with no auth-enabled
+        self.auth_basic = False
+
         # Proxy URL
         self.proxy = None
         # Safe chars for path_param

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -4,6 +4,7 @@ org=my-org
 token=my-token
 timeout=6000
 connection_pool_maxsize=55
+auth_basic=false
 
 [tags]
 id = 132-987-655

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -5,6 +5,7 @@
   active = true
   timeout = 6000
   connection_pool_maxsize = 55
+  auth_basic = False
 
 [tags]
   id = "132-987-655"

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -72,6 +72,7 @@ class InfluxDBClientTest(unittest.TestCase):
         self.assertEqual("California Miner", self.client.default_tags["customer"])
         self.assertEqual("${env.data_center}", self.client.default_tags["data_center"])
         self.assertEqual(55, self.client.api_client.configuration.connection_pool_maxsize)
+        self.assertEqual(False, self.client.api_client.configuration.auth_basic)
 
     def test_init_from_file_ssl_default(self):
         self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.ini')


### PR DESCRIPTION
feat: add option for basic auth when using influxdb 1.8 compatibility API

Closes #262

## Proposed Changes

Add an additional option ```auth_basic: True|False``` for the InfluxDBClient, which allows to use the client in cases where reverse proxies are being used for authentication instead of InfluxDBs own authentication (applies only for InfluxDB 1.8 forward compatibility API).
Using reverse proxies is quite a common setup, so this makes it easier to integrate in such scenarios.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
