### PR TITLE
chore: version of client is specified on one place

### DIFF
--- a/influxdb_client/__init__.py
+++ b/influxdb_client/__init__.py
@@ -298,4 +298,6 @@ from influxdb_client.client.write_api import WriteApi, WriteOptions
 from influxdb_client.client.influxdb_client import InfluxDBClient
 from influxdb_client.client.write.point import Point
 
-__version__ = '1.19.0dev'
+from influxdb_client.version import CLIENT_VERSION
+
+__version__ = CLIENT_VERSION

--- a/influxdb_client/api_client.py
+++ b/influxdb_client/api_client.py
@@ -76,7 +76,8 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'influxdb-client-python/1.19.0dev'
+        from influxdb_client import CLIENT_VERSION
+        self.user_agent = f'influxdb-client-python/{CLIENT_VERSION}'
 
     def __del__(self):
         """Dispose pools."""

--- a/influxdb_client/configuration.py
+++ b/influxdb_client/configuration.py
@@ -242,12 +242,13 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         :return: The report for debugging.
         """
+        from influxdb_client import CLIENT_VERSION
         return "Python SDK Debug Report:\n"\
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 2.0.0\n"\
-               "SDK Package Version: 1.19.0dev".\
-               format(env=sys.platform, pyversion=sys.version)
+               "SDK Package Version: {client_version}".\
+               format(env=sys.platform, pyversion=sys.version, client_version=CLIENT_VERSION)
 
     def update_request_header_params(self, path: str, params: dict):
         """Update header params based on custom settings.

--- a/influxdb_client/version.py
+++ b/influxdb_client/version.py
@@ -1,3 +1,3 @@
 """Version of the Client that is used in User-Agent header."""
 
-CLIENT_VERSION = '1.19.0dev'
+CLIENT_VERSION = '1.19.0dev0'

--- a/influxdb_client/version.py
+++ b/influxdb_client/version.py
@@ -1,0 +1,3 @@
+"""Version of the Client that is used in User-Agent header."""
+
+CLIENT_VERSION = '1.19.0dev'

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,12 @@ with open('README.rst', 'r') as f:
 NAME = "influxdb_client"
 
 meta = {}
-with open(Path(__file__).parent / 'influxdb_client' / '__init__.py') as f:
-    exec('\n'.join(l for l in f if l.startswith('__')), meta)
+with open(Path(__file__).parent / 'influxdb_client' / 'version.py') as f:
+    exec('\n'.join(l for l in f if l.startswith('CLIENT_VERSION')), meta)
 
 setup(
     name=NAME,
-    version=meta['__version__'],
+    version=meta['CLIENT_VERSION'],
     description="InfluxDB 2.0 Python client library",
     long_description=readme,
     url="https://github.com/influxdata/influxdb-client-python",

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -10,7 +10,7 @@ import rx
 from rx import operators as ops
 
 import influxdb_client
-from influxdb_client import WritePrecision, InfluxDBClient
+from influxdb_client import WritePrecision, InfluxDBClient, CLIENT_VERSION
 from influxdb_client.client.write.point import Point
 from influxdb_client.client.write_api import WriteOptions, WriteApi, PointSettings
 
@@ -459,7 +459,7 @@ class BatchingWriteTest(unittest.TestCase):
 
         requests = httpretty.httpretty.latest_requests
         self.assertEqual(1, len(requests))
-        self.assertEqual(f'influxdb-client-python/{influxdb_client.__version__}', requests[0].headers['User-Agent'])
+        self.assertEqual(f'influxdb-client-python/{CLIENT_VERSION}', requests[0].headers['User-Agent'])
 
     def test_to_low_flush_interval(self):
 


### PR DESCRIPTION
## Proposed Changes

The version of client is specified on one place - useful for simple release and update management.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
