### PR TITLE
fix: supports `write_precision` for write Pandas DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Deprecated
 1. [#264](https://github.com/influxdata/influxdb-client-python/pull/264): Deprecated `org_id` options BucketsApi.create_bucket in favor of `org` parameter
 
+### Bug Fixes
+1. [#270](https://github.com/influxdata/influxdb-client-python/pull/270): Supports `write_precision` for write Pandas DataFrame
+
 ## 1.18.0 [2021-06-04]
 
 ### Breaking Changes

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -312,7 +312,7 @@ class WriteApi:
             self._serialize(Point.from_dict(record, write_precision=write_precision),
                             write_precision, payload, **kwargs)
         elif 'DataFrame' in type(record).__name__:
-            _data = data_frame_to_list_of_points(record, self._point_settings, **kwargs)
+            _data = data_frame_to_list_of_points(record, self._point_settings, write_precision, **kwargs)
             self._serialize(_data, write_precision, payload, **kwargs)
 
         elif isinstance(record, Iterable):
@@ -338,7 +338,8 @@ class WriteApi:
                                  precision, **kwargs)
 
         elif 'DataFrame' in type(data).__name__:
-            self._write_batching(bucket, org, data_frame_to_list_of_points(data, self._point_settings, **kwargs),
+            self._write_batching(bucket, org,
+                                 data_frame_to_list_of_points(data, self._point_settings, precision, **kwargs),
                                  precision, **kwargs)
 
         elif isinstance(data, Iterable):


### PR DESCRIPTION
Closes #245

## Proposed Changes

The `dataframe_serializer.py` supports `write_precision`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
