### PR TITLE
feat: add __repr__ methods for FluxTable, FluxColumn, FluxRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.20.0 [unreleased]
 
+### Features
+1. [#281](https://github.com/influxdata/influxdb-client-python/pull/281): `FluxTable`, `FluxColumn` and `FluxRecord` objects have helpful reprs
+
 ## 1.19.0 [2021-07-09]
 
 ### Features

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -33,7 +33,7 @@ class FluxTable(FluxStructure):
         return cls_name + "() columns: " + str(len(self.columns)) + ", records: " + str(len(self.records))
 
     def __repr__(self):
-        """Format for inspection"""
+        """Format for inspection."""
         return f"<{type(self).__name__}: {len(self.columns)} columns, {len(self.records)} records>"
 
     def __iter__(self):
@@ -53,7 +53,7 @@ class FluxColumn(FluxStructure):
         self.index = index
 
     def __repr__(self):
-        """Format for inspection"""
+        """Format for inspection."""
         fields = [repr(self.index)] + [
             f'{name}={getattr(self, name)!r}' for name in (
                 'label', 'data_type', 'group', 'default_value'
@@ -110,6 +110,6 @@ class FluxRecord(FluxStructure):
         return cls_name + "() table: " + str(self.table) + ", " + str(self.values)
 
     def __repr__(self):
-        """Format for inspection"""
+        """Format for inspection."""
         d = self.values
         return f"<{type(self).__name__} field={d.get('_field')} value={d.get('_value')}>"

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -111,5 +111,4 @@ class FluxRecord(FluxStructure):
 
     def __repr__(self):
         """Format for inspection."""
-        d = self.values
-        return f"<{type(self).__name__} field={d.get('_field')} value={d.get('_value')}>"
+        return f"<{type(self).__name__}: field={self.values.get('_field')}, value={self.values.get('_value')}>"

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -32,6 +32,9 @@ class FluxTable(FluxStructure):
         cls_name = type(self).__name__
         return cls_name + "() columns: " + str(len(self.columns)) + ", records: " + str(len(self.records))
 
+    def __repr__(self):
+        return f"<{type(self).__name__}: {len(self.columns)} columns, {len(self.records)} records>"
+
     def __iter__(self):
         """Iterate over records."""
         return iter(self.records)
@@ -47,6 +50,14 @@ class FluxColumn(FluxStructure):
         self.data_type = data_type
         self.label = label
         self.index = index
+
+    def __repr__(self):
+        fields = [repr(self.index)] + [
+            f'{name}={getattr(self, name)!r}' for name in (
+                'label', 'data_type', 'group', 'default_value'
+            ) if getattr(self, name) is not None
+        ]
+        return f"{type(self).__name__}({', '.join(fields)})"
 
 
 class FluxRecord(FluxStructure):
@@ -95,3 +106,7 @@ class FluxRecord(FluxStructure):
         """Return formatted output."""
         cls_name = type(self).__name__
         return cls_name + "() table: " + str(self.table) + ", " + str(self.values)
+
+    def __repr__(self):
+        d = self.values
+        return f"<{type(self).__name__} field={d.get('_field')} value={d.get('_value')}>"

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -33,6 +33,7 @@ class FluxTable(FluxStructure):
         return cls_name + "() columns: " + str(len(self.columns)) + ", records: " + str(len(self.records))
 
     def __repr__(self):
+        """Format for inspection"""
         return f"<{type(self).__name__}: {len(self.columns)} columns, {len(self.records)} records>"
 
     def __iter__(self):
@@ -52,6 +53,7 @@ class FluxColumn(FluxStructure):
         self.index = index
 
     def __repr__(self):
+        """Format for inspection"""
         fields = [repr(self.index)] + [
             f'{name}={getattr(self, name)!r}' for name in (
                 'label', 'data_type', 'group', 'default_value'
@@ -108,5 +110,6 @@ class FluxRecord(FluxStructure):
         return cls_name + "() table: " + str(self.table) + ", " + str(self.values)
 
     def __repr__(self):
+        """Format for inspection"""
         d = self.values
         return f"<{type(self).__name__} field={d.get('_field')} value={d.get('_value')}>"


### PR DESCRIPTION
## Proposed Changes

`__repr__` methods are a convenient feature for exploring objects interactively - i.e. in an interactive shell or a Jupyter notebook. The default representation of an object basically just identifies the type:

```
<influxdb_client.client.flux_table.FluxRecord at 0x7f5720b63460>
```

By defining `__repr__`, objects can display themselves with more useful information:

```
<FluxTable: 11 columns, 360 records>
FluxColumn(7, label='_measurement', data_type='string', group=True, default_value='')
<FluxRecord field=counter value=282.0>
```

There are loose conventions for how reprs are formatted, though I'm not aware of any reference for them. They generally fit on one line, to simplify formatting in containers. If it's practical to fit in all the information to reconstruct the object, the repr should be a code snippet to construct it (as I've done with FluxColumn). If not, the repr usually looks like `<ClassName detail>`, with whatever details are most likely to convey useful information. I've had a guess at what might be useful for FluxTable & FluxRecord, but I'm happy to revise them.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
