### PR TITLE
fix: set proxy server in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#281](https://github.com/influxdata/influxdb-client-python/pull/281): `FluxTable`, `FluxColumn` and `FluxRecord` objects have helpful reprs
 
+### Bug Fixes
+1. [#283](https://github.com/influxdata/influxdb-client-python/pull/283): Set proxy server in config file
+
 ## 1.19.0 [2021-07-09]
 
 ### Features

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -115,6 +115,7 @@ class InfluxDBClient(object):
             - connection_pool_maxsize
             - auth_basic
             - profilers
+            - proxy
 
 
         config.ini example::
@@ -127,6 +128,7 @@ class InfluxDBClient(object):
             connection_pool_maxsize=25
             auth_basic=false
             profilers=query,operator
+            proxy=http:proxy.domain.org:8080
 
             [tags]
             id = 132-987-655
@@ -143,6 +145,7 @@ class InfluxDBClient(object):
                 connection_pool_maxsize = 25
                 auth_basic = false
                 profilers="query, operator"
+                proxy = "http://proxy.domain.org:8080"
 
             [tags]
                 id = "132-987-655"
@@ -192,10 +195,14 @@ class InfluxDBClient(object):
         if config.has_option('influx2', 'profilers'):
             profilers = [x.strip() for x in config_value('profilers').split(',')]
 
+        proxy = None
+        if config.has_option('influx2', 'proxy'):
+            proxy = config_value('proxy')
+
         return cls(url, token, debug=debug, timeout=_to_int(timeout), org=org, default_tags=default_tags,
                    enable_gzip=enable_gzip, verify_ssl=_to_bool(verify_ssl), ssl_ca_cert=ssl_ca_cert,
                    connection_pool_maxsize=_to_int(connection_pool_maxsize), auth_basic=_to_bool(auth_basic),
-                   profilers=profilers)
+                   profilers=profilers, proxy=proxy)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False):

--- a/tests/config-enabled-proxy.ini
+++ b/tests/config-enabled-proxy.ini
@@ -1,0 +1,14 @@
+[influx2]
+url=http://localhost:8086
+org=my-org
+token=my-token
+timeout=6000
+connection_pool_maxsize=55
+auth_basic=false
+profilers=query, operator
+proxy=http://proxy.domain.org:8080
+
+[tags]
+id = 132-987-655
+customer = California Miner
+data_center = ${env.data_center}

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -75,6 +75,11 @@ class InfluxDBClientTest(unittest.TestCase):
         self.assertEqual(False, self.client.api_client.configuration.auth_basic)
         self.assertEqual(["query", "operator"], self.client.profilers)
 
+    def test_init_from_file_proxy(self):
+        self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config-enabled-proxy.ini')
+        self.assertConfig()
+        self.assertEqual("http://proxy.domain.org:8080", self.client.api_client.configuration.proxy)
+
     def test_init_from_file_ssl_default(self):
         self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.ini')
 


### PR DESCRIPTION
The proxy option was not parsed in the config file.

Closes #

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
