### PR TITLE
fix: out of range in parsing a Flux response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#283](https://github.com/influxdata/influxdb-client-python/pull/283): Set proxy server in config file
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `Threshold` domain models mapping 
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `DashboardService` responses types
+1. [#297](https://github.com/influxdata/influxdb-client-python/pull/297): Potential out of range in parsing a Flux response
 
 ## 1.19.0 [2021-07-09]
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -86,7 +86,7 @@ class FluxCsvParser(object):
             if len(csv) < 1:
                 continue
 
-            if "error" == csv[1] and "reference" == csv[2]:
+            if len(csv) >= 3 and "error" == csv[1] and "reference" == csv[2]:
                 parsing_state_error = True
                 continue
 


### PR DESCRIPTION
Closes #295

## Proposed Changes

Fixed potential out of range.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
