### PR TITLE
chore(release): deploy package to Anaconda.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `Threshold` domain models mapping 
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `DashboardService` responses types
 
+### CI
+1. [#299](https://github.com/influxdata/influxdb-client-python/pull/299): Deploy package to [Anaconda.org](https://anaconda.org/influxdata/influxdb_client)
+
 ## 1.19.0 [2021-07-09]
 
 ### Features

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ influxdb-client-python
    :target: https://pypi.org/project/influxdb-client/
    :alt: PyPI package
 
+.. image:: https://anaconda.org/influxdata/influxdb_client/badges/version.svg
+   :target: https://anaconda.org/influxdata/influxdb_client
+   :alt: Anaconda.org package
+
 .. image:: https://img.shields.io/pypi/pyversions/influxdb-client.svg
    :target: https://pypi.python.org/pypi/influxdb-client
    :alt: Supported Python versions

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "influxdb_client" %}
+{% set version = "1.19.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.python.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8954562259dd3770d89cd3db13cbe48e44c56e000f8af377b8c606f7c91c5f58
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - setuptools
+#    - rx >=3.0.1
+#    - certifi >=14.05.14
+#    - six >=1.10
+#    - python_dateutil >=2.5.3
+#    - setuptools >=21.0.0
+#    - urllib3 >=1.15.1
+#    - pytz >=2019.1
+
+about:
+  home: https://github.com/influxdata/influxdb-client-python
+  license: MIT License
+  license_file: ../LICENSE
+  summary: The Python client library for the InfluxDB 2.0.
+  dev_url: https://github.com/influxdata/influxdb-client-python
+


### PR DESCRIPTION
## Proposed Changes

This PR bring support for deploying `influxdb-client-python` to Anaconda.org - https://anaconda.org/influxdata/influxdb_client

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
