### PR TITLE
feat: add `proxy_headers` to configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Features
 1. [#281](https://github.com/influxdata/influxdb-client-python/pull/281): `FluxTable`, `FluxColumn` and `FluxRecord` objects have helpful reprs
 1. [#293](https://github.com/influxdata/influxdb-client-python/pull/293): `dataframe_serializer` supports batching
+1. [#301](https://github.com/influxdata/influxdb-client-python/pull/301): Add `proxy_headers` to configuration options
+
+### Documentation
+1. [#301](https://github.com/influxdata/influxdb-client-python/pull/301): How to configure proxy
 
 ### Bug Fixes
 1. [#283](https://github.com/influxdata/influxdb-client-python/pull/283): Set proxy server in config file

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ InfluxDB 2.0 client features
     - `How to use Jupyter + Pandas + InfluxDB 2`_
 - Advanced Usage
     - `Gzip support`_
+    - `Proxy configuration`_
     - `Delete data`_
 
 Installation
@@ -1058,6 +1059,41 @@ Gzip support
    _db_client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org", enable_gzip=True)
 
 .. marker-gzip-end
+
+Proxy configuration
+^^^^^^^^^^^^^^^^^^^
+.. marker-proxy-start
+
+You can configure the client to tunnel requests through an HTTP proxy.
+The following proxy options are supported:
+
+- ``proxy`` - Set this to configure the http proxy to be used, ex. ``http://localhost:3128``
+- ``proxy_headers`` - A dictionary containing headers that will be sent to the proxy. Could be used for proxy authentication.
+
+.. code-block:: python
+
+   from influxdb_client import InfluxDBClient
+
+   with InfluxDBClient(url="http://localhost:8086",
+                       token="my-token",
+                       org="my-org",
+                       proxy="http://localhost:3128") as client:
+
+.. note::
+
+    If your proxy notify the client with permanent redirect (``HTTP 301``) to **different host**.
+    The client removes ``Authorization`` header, because otherwise the contents of ``Authorization`` is sent to third parties
+    which is a security vulnerability.
+
+    You can change this behaviour by:
+
+    .. code-block:: python
+
+       from urllib3 import Retry
+       Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset()
+       Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
+
+.. marker-proxy-end
 
 Delete data
 ^^^^^^^^^^^

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,17 +10,17 @@ Query
   :start-after: marker-query-start
   :end-before: marker-query-end
 
-Pandas DataFrame
-^^^^^^^^^^^^^^^^
-.. include:: ../README.rst
-  :start-after: marker-pandas-start
-  :end-before: marker-pandas-end
-
 Write
 ^^^^^
 .. include:: ../README.rst
   :start-after: marker-writes-start
   :end-before: marker-writes-end
+
+Pandas DataFrame
+^^^^^^^^^^^^^^^^
+.. include:: ../README.rst
+  :start-after: marker-pandas-start
+  :end-before: marker-pandas-end
 
 Delete data
 ^^^^^^^^^^^
@@ -33,6 +33,12 @@ Gzip support
 .. include:: ../README.rst
   :start-after: marker-gzip-start
   :end-before: marker-gzip-end
+
+Proxy configuration
+^^^^^^^^^^^^^^^^^^^
+.. include:: ../README.rst
+  :start-after: marker-proxy-start
+  :end-before: marker-proxy-end
 
 Debugging
 ^^^^^^^^^

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -38,6 +38,8 @@ class InfluxDBClient(object):
         :key bool verify_ssl: Set this to false to skip verifying SSL certificate when calling API from https server.
         :key str ssl_ca_cert: Set this to customize the certificate file to verify the peer.
         :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
         :key int connection_pool_maxsize: Number of connections to save that can be reused by urllib3.
                                           Defaults to "multiprocessing.cpu_count() * 5".
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
@@ -63,6 +65,7 @@ class InfluxDBClient(object):
         conf.verify_ssl = kwargs.get('verify_ssl', True)
         conf.ssl_ca_cert = kwargs.get('ssl_ca_cert', None)
         conf.proxy = kwargs.get('proxy', None)
+        conf.proxy_headers = kwargs.get('proxy_headers', None)
         conf.connection_pool_maxsize = kwargs.get('connection_pool_maxsize', conf.connection_pool_maxsize)
         conf.timeout = timeout
 

--- a/influxdb_client/configuration.py
+++ b/influxdb_client/configuration.py
@@ -112,6 +112,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
 
         # Proxy URL
         self.proxy = None
+        # A dictionary containing headers that will be sent to the proxy
+        self.proxy_headers = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
 

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -107,6 +107,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
+                proxy_headers=configuration.proxy_headers,
                 **addition_pool_args
             )
         else:


### PR DESCRIPTION
Closes #300 
Closes #294

## Proposed Changes

1. added `proxy_headers` to configuration options
1. added docs how to configure proxy 

![image](https://user-images.githubusercontent.com/455137/129187448-6dffe1f5-ddca-402d-a42a-63c2c4f2bbc7.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
