### PR TITLE
fix: backslash escaping in serialization to Line protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#283](https://github.com/influxdata/influxdb-client-python/pull/283): Set proxy server in config file
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `Threshold` domain models mapping 
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `DashboardService` responses types
+1. [#303](https://github.com/influxdata/influxdb-client-python/pull/303): Backslash escaping in serialization to Line protocol
 
 ## 1.19.0 [2021-07-09]
 

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -18,7 +18,6 @@ EPOCH = UTC.localize(datetime.utcfromtimestamp(0))
 DEFAULT_WRITE_PRECISION = WritePrecision.NS
 
 _ESCAPE_MEASUREMENT = str.maketrans({
-    '\\': r'\\',      # Note: this is wrong. Backslashes are not escaped like this in measurements.
     ',': r'\,',
     ' ': r'\ ',
     '\n': r'\n',
@@ -27,7 +26,6 @@ _ESCAPE_MEASUREMENT = str.maketrans({
 })
 
 _ESCAPE_KEY = str.maketrans({
-    '\\': r'\\',      # Note: this is wrong. Backslashes are not escaped like this in keys.
     ',': r'\,',
     '=': r'\=',
     ' ': r'\ ',

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -267,7 +267,7 @@ class PointTest(unittest.TestCase):
         point._tags = {
             "empty_tag": "",
             "none_tag": None,
-            "backslash_tag": "C:\\",
+            "backslash_tag": "C:\\\\",
             "integer_tag": 2,
             "string_tag": "hello"
         }
@@ -378,6 +378,15 @@ class PointTest(unittest.TestCase):
         exception = ve.exception
 
         self.assertEqual('Type: "<class \'pytz.UTC\'>" of field: "level" is not supported.', f'{exception}')
+
+    def test_backslash(self):
+        point = Point.from_dict({"measurement": "test",
+                                 "tags": {"tag1": "value1", "tag2": "value\2", "tag3": "value\\3",
+                                          "tag4": r"value\4", "tag5": r"value\\5"}, "time": 1624989000000000000,
+                                 "fields": {"value": 10}}, write_precision=WritePrecision.NS)
+        self.assertEqual(
+            "test,tag1=value1,tag2=value\2,tag3=value\\3,tag4=value\\4,tag5=value\\\\5 value=10i 1624989000000000000",
+            point.to_line_protocol())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #302

## Proposed Changes

The backslash does not have to be escaped in `Measurement`, `Tag key`, `Tag value` and `Field key`. For more info see:

https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol/#special-characters

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
