### PR TITLE
fix: ensuring aws lambda compatible zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `Threshold` domain models mapping 
 1. [#290](https://github.com/influxdata/influxdb-client-python/pull/290): `DashboardService` responses types
 1. [#303](https://github.com/influxdata/influxdb-client-python/pull/303): Backslash escaping in serialization to Line protocol
+1. [#312](https://github.com/influxdata/influxdb-client-python/pull/312): Zip structure for AWS Lambda
 
 ## 1.19.0 [2021-07-09]
 

--- a/docker/aws_lambda_layer/Dockerfile
+++ b/docker/aws_lambda_layer/Dockerfile
@@ -11,5 +11,6 @@ RUN source lambda/bin/activate
 # Python dependencies to be included in output zip file:
 RUN python3.8 -m pip install --no-cache-dir influxdb-client[ciso] -t /install/python
 # Create zip file
-RUN zip -r /install/python.zip python/
+WORKDIR /install/python
+RUN zip -r ../python.zip .
 VOLUME ["/install"]


### PR DESCRIPTION
i was following the instructions here: https://github.com/influxdata/influxdb-client-python/tree/master/docker/aws_lambda_layer#readme

but noticed that the zip file created contained files that start with the `/python/` prefix. To be compatible with aws lambda, the packages should be in the root.

previous zip structure:
```
(base) ➜  kinesisToInfluxDBCloud unzip -vl python.zip | head
Archive:  python.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/rx/
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/rx/py.typed
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/rx/core/
    9565  Defl:N     1855  81% 08-17-2021 22:25 c968ac4a  python/rx/core/typing.py
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/rx/core/observer/
       0  Stored        0   0% 08-17-2021 22:25 00000000  python/rx/core/observer/__pycache__/
```

new zip structure:
```
(base) ➜  kinesisToInfluxDBCloud unzip -vl python.zip | head
Archive:  python.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Stored        0   0% 08-17-2021 22:25 00000000  rx/
       0  Stored        0   0% 08-17-2021 22:25 00000000  rx/py.typed
       0  Stored        0   0% 08-17-2021 22:25 00000000  rx/core/
    9565  Defl:N     1855  81% 08-17-2021 22:25 c968ac4a  rx/core/typing.py
       0  Stored        0   0% 08-17-2021 22:25 00000000  rx/core/observer/
       0  Stored        0   0% 08-17-2021 22:25 00000000 rx/core/observer/__pycache__/
```


## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
