### PR TITLE
docs: add link about `Nanosecond precision` to usage page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,10 @@ InfluxDB 2.0 client features
     - `How to efficiently import large dataset`_
     - `Efficiency write data from IOT sensor`_
     - `How to use Jupyter + Pandas + InfluxDB 2`_
-- Advanced Usage
+- `Advanced Usage`_
     - `Gzip support`_
     - `Proxy configuration`_
+    - `Nanosecond precision`_
     - `Delete data`_
 
 Installation
@@ -1163,6 +1164,7 @@ For more info about how configure HTTP retry see details in `urllib3 documentati
 
 Nanosecond precision
 ^^^^^^^^^^^^^^^^^^^^
+.. marker-nanosecond-start
 
 The Python's `datetime <https://docs.python.org/3/library/datetime.html>`_ doesn't support precision with nanoseconds
 so the library during writes and queries ignores everything after microseconds.
@@ -1226,6 +1228,7 @@ that is replacement for python ``datetime.datetime`` object and also you should 
     """
     client.close()
 
+.. marker-nanosecond-end
 
 Local tests
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -40,6 +40,12 @@ Proxy configuration
   :start-after: marker-proxy-start
   :end-before: marker-proxy-end
 
+Nanosecond precision
+^^^^^^^^^^^^^^^^^^^^
+.. include:: ../README.rst
+  :start-after: marker-nanosecond-start
+  :end-before: marker-nanosecond-end
+
 Debugging
 ^^^^^^^^^
 


### PR DESCRIPTION
Closes #314

## Proposed Changes

Added link about `Nanosecond precision` to usage page:

![Screenshot 2021-08-19 at 7 21 46](https://user-images.githubusercontent.com/455137/130012754-ae9adc59-88dd-43ba-b7b4-851876f5b77f.png)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
