### PR TITLE
feat: `delete_api` also accept `datetime` as a value for `start` and `stop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#319](https://github.com/influxdata/influxdb-client-python/pull/319): Add supports for array expressions in query parameters
 2. [#320](https://github.com/influxdata/influxdb-client-python/pull/320): Add JSONEncoder to encode query results to JSON
+1. [#317](https://github.com/influxdata/influxdb-client-python/pull/317): `delete_api` also accept `datetime` as a value for `start` and `stop`
 
 ### Bug Fixes
 1. [#321](https://github.com/influxdata/influxdb-client-python/pull/321): Fixes return type for dashboard when `include=properties` is used

--- a/influxdb_client/client/delete_api.py
+++ b/influxdb_client/client/delete_api.py
@@ -1,6 +1,5 @@
 """Delete time series data from InfluxDB."""
 
-import datetime
 from datetime import datetime
 
 from influxdb_client import DeleteService, DeletePredicateRequest
@@ -26,7 +25,6 @@ class DeleteApi(object):
         :param org: organization id or name
         :return:
         """
-
         date_helper = get_date_helper()
         if isinstance(start, datetime):
             start = date_helper.to_utc(start)

--- a/influxdb_client/client/delete_api.py
+++ b/influxdb_client/client/delete_api.py
@@ -1,8 +1,10 @@
 """Delete time series data from InfluxDB."""
 
 import datetime
+from datetime import datetime
 
 from influxdb_client import DeleteService, DeletePredicateRequest
+from influxdb_client.client.util.date_utils import get_date_helper
 
 
 class DeleteApi(object):
@@ -24,5 +26,12 @@ class DeleteApi(object):
         :param org: organization id or name
         :return:
         """
+
+        date_helper = get_date_helper()
+        if isinstance(start, datetime):
+            start = date_helper.to_utc(start)
+        if isinstance(stop, datetime):
+            stop = date_helper.to_utc(stop)
+
         predicate_request = DeletePredicateRequest(start=start, stop=stop, predicate=predicate)
         return self._service.post_delete(delete_predicate_request=predicate_request, bucket=bucket, org=org)


### PR DESCRIPTION
Closes #313

## Proposed Changes

The use can use `datetime` without timezone as a parameter for `delete_api`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
