### PR TITLE
feat: add supports for array expressions in query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.21.0 [unreleased]
 
+### Features
+1. [#xxx](https://github.com/influxdata/influxdb-client-python/pull/xxx): Add supports for array expressions in query parameters
+ 
 ## 1.20.0 [2021-08-20]
 
 ### Features

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -5,7 +5,7 @@ import unittest
 from dateutil.tz import tzutc
 from httpretty import httpretty
 
-from influxdb_client import QueryApi, DurationLiteral, Duration, CallExpression, Expression, UnaryExpression, \
+from influxdb_client import QueryApi, DurationLiteral, Duration, CallExpression, UnaryExpression, \
     Identifier, InfluxDBClient
 from influxdb_client.client.query_api import QueryOptions
 from influxdb_client.client.util.date_utils import get_date_helper
@@ -47,7 +47,7 @@ class SimpleQueryTest(BaseTest):
         val_count = 0
         for table in tables:
             for row in table:
-                for cell in row.values:
+                for _ in row.values:
                     val_count += 1
 
         print("Values count: ", val_count)
@@ -61,7 +61,7 @@ class SimpleQueryTest(BaseTest):
 
         val_count = 0
         for row in csv_result:
-            for cell in row:
+            for _ in row:
                 val_count += 1
 
         print("Values count: ", val_count)
@@ -98,7 +98,7 @@ class SimpleQueryTest(BaseTest):
 
         val_count = 0
         for row in csv_result:
-            for cell in row:
+            for _ in row:
                 val_count += 1
 
         print("Values count: ", val_count)
@@ -263,7 +263,39 @@ class SimpleQueryTest(BaseTest):
                      }
                  ],
                  "imports": []
-             }]]
+             }], ["arrayParam", ["bar1", "bar2", "bar3"],
+                  {
+                      "body": [
+                          {
+                              "assignment": {
+                                  "id": {
+                                      "name": "arrayParam",
+                                      "type": "Identifier"
+                                  },
+                                  "init": {
+                                      "elements": [
+                                          {
+                                              "type": "StringLiteral",
+                                              "value": "bar1"
+                                          },
+                                          {
+                                              "type": "StringLiteral",
+                                              "value": "bar2"
+                                          },
+                                          {
+                                              "type": "StringLiteral",
+                                              "value": "bar3"
+                                          }
+                                      ],
+                                      "type": "ArrayExpression"
+                                  },
+                                  "type": "VariableAssignment"
+                              },
+                              "type": "OptionStatement"
+                          }
+                      ],
+                      "imports": []
+                  }]]
 
         for data in test_data:
             param = {data[0]: data[1]}
@@ -290,7 +322,7 @@ class SimpleQueryTest(BaseTest):
         for table in csv_result:
             self.assertFalse(any(filter(lambda column: (column.default_value == "_profiler"), table.columns)))
             for flux_record in table:
-                self.assertFalse( flux_record["_measurement"].startswith("profiler/"))
+                self.assertFalse(flux_record["_measurement"].startswith("profiler/"))
 
         records = self.client.query_api().query_stream(query=q, params=p)
 


### PR DESCRIPTION
Closes #318

## Proposed Changes

Add supports for array in query parameters. Following queries are now supported:

```python
query_api.query('''
from(bucket: "my-bucket")
  |> range(start: -6h, stop: now())
  |> filter(fn: (r) => contains(value: r.location, set: bars))
  |> last()
''', params={"bars": ["Prague", "Berlin", "Rome"]})
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
