### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ commands:
       - restore_cache:
           name: Restoring Pip Cache
           keys:
-            - &cache-key pip-cache-v9-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-{{ checksum "setup.py" }}
-            - pip-cache-v9-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-
+            - &cache-key pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-{{ checksum "setup.py" }}
+            - pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-
       - run:
           command: |  # use pipenv to install dependencies
             sudo pip install pipenv
@@ -46,7 +46,7 @@ jobs:
     parameters:
       python-image:
         type: string
-        default: &default-python "circleci/python:3.6-buster"
+        default: &default-python "cimg/python:3.6"
       influxdb-image:
         type: string
         default: &default-influxdb "influxdb:latest"
@@ -173,13 +173,13 @@ workflows:
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-python:
           name: test-3.7
-          python-image: "circleci/python:3.7-buster"
+          python-image: "cimg/python:3.7"
       - tests-python:
           name: test-3.8
-          python-image: "circleci/python:3.8-buster"
+          python-image: "cimg/python:3.8"
       - tests-python:
           name: test-3.9
-          python-image: "circleci/python:3.9-buster"
+          python-image: "cimg/python:3.9"
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,8 @@ commands:
       - restore_cache:
           name: Restoring Pip Cache
           keys:
-            - &cache-key pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-{{ checksum "setup.py" }}
-            - pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-
-#      - run:
-#          command: |  # use pipenv to install dependencies
-#            sudo pip install pipenv
+            - &cache-key pip-cache-v11-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-{{ checksum "setup.py" }}
+            - pip-cache-v11-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-
       - run:
           name: "Running tests"
           command: ./scripts/ci-test.sh
@@ -93,6 +90,7 @@ jobs:
       - run:
           name: Checks that the description will render correctly on PyPI.
           command: |
+            pip install setuptools_rust --user
             pip install twine --user
             python setup.py sdist bdist_wheel
             twine check dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run:
           name: Checks that the description will render correctly on PyPI.
           command: |
-            pip install setuptools_rust --user
+            pip install --upgrade pip
             pip install twine --user
             python setup.py sdist bdist_wheel
             twine check dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ commands:
           keys:
             - &cache-key pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-{{ checksum "setup.py" }}
             - pip-cache-v10-<< parameters.python-image >>-<< parameters.enabled-ciso-8601 >>-
-      - run:
-          command: |  # use pipenv to install dependencies
-            sudo pip install pipenv
+#      - run:
+#          command: |  # use pipenv to install dependencies
+#            sudo pip install pipenv
       - run:
           name: "Running tests"
           command: ./scripts/ci-test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Bug Fixes
 1. [#321](https://github.com/influxdata/influxdb-client-python/pull/321): Fixes return type for dashboard when `include=properties` is used
+
+### CI
+1. [#327](https://github.com/influxdata/influxdb-client-python/pull/327): Switch to next-gen CircleCI's convenience images
  
 ## 1.20.0 [2021-08-20]
 


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
