### PR TITLE
feat: add supports for write `NamedTuple`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
             export PYTHONPATH="$PWD"
             python examples/monitoring_and_alerting.py
             python examples/buckets_management.py
+            python examples/write_structured_data.py
   check-sphinx:
     docker:
       - image: *default-python

--- a/README.rst
+++ b/README.rst
@@ -358,11 +358,13 @@ The data could be written as
 
 1. ``string`` or ``bytes`` that is formatted as a InfluxDB's line protocol
 2. `Data Point <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/write/point.py#L16>`__ structure
-3. Dictionary style mapping with keys: ``measurement``, ``tags``, ``fields`` and ``time``
-4. List of above items
-5. A ``batching`` type of write also supports an ``Observable`` that produce one of an above item
-6. `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
+3. Dictionary style mapping with keys: ``measurement``, ``tags``, ``fields`` and ``time`` or custom structure
+4. `NamedTuple <https://docs.python.org/3/library/collections.html#collections.namedtuple>`_
+5. List of above items
+6. A ``batching`` type of write also supports an ``Observable`` that produce one of an above item
+7. `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
 
+You can find write examples at GitHub: `influxdb-client-python/examples <https://github.com/influxdata/influxdb-client-python/tree/master/examples#writes>`_.
 
 Batching
 """"""""
@@ -528,7 +530,7 @@ In a `init <https://docs.python.org/3/library/configparser.html>`_ configuration
     customer = California Miner
     data_center = ${env.data_center}
 
-You could also use a `TOML <https://toml.io/en/>`_ format for the configuration file.
+You can also use a `TOML <https://toml.io/en/>`_ format for the configuration file.
 
 Via Environment Properties
 __________________________
@@ -1044,7 +1046,7 @@ The second example shows how to use client capabilities to realtime visualizatio
 Other examples
 """"""""""""""
 
-You could find all examples at GitHub: `influxdb-client-python/examples <https://github.com/influxdata/influxdb-client-python/tree/master/examples#examples>`_.
+You can find all examples at GitHub: `influxdb-client-python/examples <https://github.com/influxdata/influxdb-client-python/tree/master/examples#examples>`_.
 
 .. marker-examples-end
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,6 +19,12 @@ WriteApi
 .. autoclass:: influxdb_client.WriteApi
    :members:
 
+.. autoclass:: influxdb_client.client.write.point.Point
+   :members:
+
+.. autoclass:: influxdb_client.domain.write_precision.WritePrecision
+   :members:
+
 BucketsApi
 """"""""""
 .. autoclass:: influxdb_client.BucketsApi

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@
 - [ingest_large_dataframe.py](ingest_large_dataframe.py) - How to ingest large DataFrame
 - [iot_sensor.py](iot_sensor.py) - How to write sensor data every minute by [RxPY](https://rxpy.readthedocs.io/en/latest/)
 - [import_data_set_sync_batching.py](import_data_set_sync_batching.py) - How to use [RxPY](https://rxpy.readthedocs.io/en/latest/) to prepare batches for synchronous write into InfluxDB
+- [write_structured_data.py](write_structured_data.py) - How to write structured data - [NamedTuple](https://docs.python.org/3/library/collections.html#collections.namedtuple)
 
 ## Queries
 - [query.py](query.py) - How to query data into `FluxTable`s, `Stream` and `CSV`

--- a/examples/example.py
+++ b/examples/example.py
@@ -37,4 +37,4 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org",
     print("val count: ", val_count)
 
     response = query_api.query_raw('from(bucket:"my-bucket") |> range(start: -10m)')
-    print (codecs.decode(response.data))
+    print(codecs.decode(response.data))

--- a/examples/write_structured_data.py
+++ b/examples/write_structured_data.py
@@ -1,0 +1,47 @@
+from collections import namedtuple
+from datetime import datetime
+
+from influxdb_client import InfluxDBClient
+from influxdb_client.client.write_api import SYNCHRONOUS
+
+
+class Sensor(namedtuple('Sensor', ['name', 'location', 'version', 'pressure', 'temperature', 'timestamp'])):
+    """
+    Sensor named structure
+    """
+    pass
+
+
+"""
+Initialize client
+"""
+with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+    write_api = client.write_api(write_options=SYNCHRONOUS)
+
+    """
+    Sensor "current" value
+    """
+    sensor = Sensor(name="sensor_pt859",
+                    location="warehouse_125",
+                    version="2021.06.05.5874",
+                    pressure=125,
+                    temperature=10,
+                    timestamp=datetime.utcnow())
+    print(sensor)
+
+    """
+    Synchronous write
+    """
+    write_api.write(bucket="my-bucket",
+                    record=sensor,
+                    dictionary_measurement_key="name",
+                    dictionary_time_key="timestamp",
+                    dictionary_tag_keys=["location", "version"],
+                    dictionary_field_keys=["pressure", "temperature"])
+
+    from influxdb_client import Point
+    point = Point("h2o_feet")\
+        .tag("location", "coyote_creek")\
+        .field("water_level", 4.0)\
+        .time(4)
+    write_api.write("my-bucket", "my-org", point)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -408,6 +408,70 @@ class PointTest(unittest.TestCase):
 
         self.assertEqual("h2o,location=europe np.float1=1.123,np.float2=2.123,np.float3=3.123,np.float4=4.123,np.int1=1i,np.int2=2i,np.int3=3i,np.int4=4i,np.uint1=5i,np.uint2=6i,np.uint3=7i,np.uint4=8i", point.to_line_protocol())
 
+    def test_from_dictionary_custom_measurement(self):
+        dictionary = {
+            "name": "test",
+            "tags": {"tag": "a"},
+            "fields": {"value": 1},
+            "time": 1,
+        }
+        point = Point.from_dict(dictionary, dictionary_measurement_key="name")
+        self.assertEqual("test,tag=a value=1i 1", point.to_line_protocol())
+
+    def test_from_dictionary_custom_time(self):
+        dictionary = {
+            "name": "test",
+            "tags": {"tag": "a"},
+            "fields": {"value": 1},
+            "created": 100250,
+        }
+        point = Point.from_dict(dictionary,
+                                dictionary_measurement_key="name",
+                                dictionary_time_key="created")
+        self.assertEqual("test,tag=a value=1i 100250", point.to_line_protocol())
+
+    def test_from_dictionary_custom_tags(self):
+        dictionary = {
+            "name": "test",
+            "tag_a": "a",
+            "tag_b": "b",
+            "fields": {"value": 1},
+            "time": 1,
+        }
+        point = Point.from_dict(dictionary,
+                                dictionary_measurement_key="name",
+                                dictionary_tag_keys=["tag_a", "tag_b"])
+        self.assertEqual("test,tag_a=a,tag_b=b value=1i 1", point.to_line_protocol())
+
+    def test_from_dictionary_custom_fields(self):
+        dictionary = {
+            "name": "sensor_pt859",
+            "location": "warehouse_125",
+            "version": "2021.06.05.5874",
+            "pressure": 125,
+            "temperature": 10,
+            "time": 1632208639,
+        }
+        point = Point.from_dict(dictionary,
+                                write_precision=WritePrecision.S,
+                                dictionary_measurement_key="name",
+                                dictionary_tag_keys=["location", "version"],
+                                dictionary_field_keys=["pressure", "temperature"])
+        self.assertEqual("sensor_pt859,location=warehouse_125,version=2021.06.05.5874 pressure=125i,temperature=10i 1632208639", point.to_line_protocol())
+
+    def test_from_dictionary_tolerant_to_missing_tags_and_fields(self):
+        dictionary = {
+            "name": "sensor_pt859",
+            "location": "warehouse_125",
+            "pressure": 125
+        }
+        point = Point.from_dict(dictionary,
+                                write_precision=WritePrecision.S,
+                                dictionary_measurement_key="name",
+                                dictionary_tag_keys=["location", "version"],
+                                dictionary_field_keys=["pressure", "temperature"])
+        self.assertEqual("sensor_pt859,location=warehouse_125 pressure=125i", point.to_line_protocol())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #289
Related to #259

## Proposed Changes

1. Added supports for write `NamedTuple` type
1. Added example how to write structured data
 
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
