### PR TITLE
feat: update management API - `BucketsApi`, `OrganizationsApi`, `UsersApi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.24.0 [unreleased]
 
+### Features
+1. [#358](https://github.com/influxdata/influxdb-client-python/pull/358): Add possibility to update `Bucket` from API
+
 ## 1.23.0 [2021-10-26]
 
 ### Deprecates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.24.0 [unreleased]
 
 ### Features
-1. [#358](https://github.com/influxdata/influxdb-client-python/pull/358): Add possibility to update `Bucket`, `Organization` from API
+1. [#358](https://github.com/influxdata/influxdb-client-python/pull/358): Update management API:
+   - `BucketsApi` - add possibility to: `update`
+   - `OrganizationsApi` - add possibility to: `update`
+   - `UsersApi` - add possibility to: `update`, `delete`, `find`
 
 ## 1.23.0 [2021-10-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.24.0 [unreleased]
 
 ### Features
-1. [#358](https://github.com/influxdata/influxdb-client-python/pull/358): Add possibility to update `Bucket` from API
+1. [#358](https://github.com/influxdata/influxdb-client-python/pull/358): Add possibility to update `Bucket`, `Organization` from API
 
 ## 1.23.0 [2021-10-26]
 

--- a/examples/buckets_management.py
+++ b/examples/buckets_management.py
@@ -25,6 +25,14 @@ with InfluxDBClient(url=url, token=token) as client:
     print(created_bucket)
 
     """
+    Update Bucket
+    """
+    print(f"------- Update -------\n")
+    created_bucket.description = "Update description"
+    created_bucket = buckets_api.update_bucket(bucket=created_bucket)
+    print(created_bucket)
+
+    """
     List all Buckets
     """
     print(f"\n------- List -------\n")
@@ -39,4 +47,3 @@ with InfluxDBClient(url=url, token=token) as client:
     print(f"------- Delete -------\n")
     buckets_api.delete_bucket(created_bucket)
     print(f" successfully deleted bucket: {created_bucket.name}")
-

--- a/influxdb_client/client/bucket_api.py
+++ b/influxdb_client/client/bucket_api.py
@@ -6,7 +6,7 @@ A bucket belongs to an organization.
 """
 import warnings
 
-from influxdb_client import BucketsService, Bucket, PostBucketRequest
+from influxdb_client import BucketsService, Bucket, PostBucketRequest, PatchBucketRequest
 from influxdb_client.client.util.helpers import get_org_query_param
 
 
@@ -58,13 +58,23 @@ class BucketsApi(object):
 
         return self._buckets_service.post_buckets(post_bucket_request=bucket)
 
+    def update_bucket(self, bucket: Bucket):
+        """Update a bucket.
+
+        :param bucket: Bucket update to apply (required)
+        :return: Bucket
+        """
+        request = PatchBucketRequest(name=bucket.name,
+                                     description=bucket.description,
+                                     retention_rules=bucket.retention_rules)
+
+        return self._buckets_service.patch_buckets_id(bucket_id=bucket.id, patch_bucket_request=request)
+
     def delete_bucket(self, bucket):
         """Delete a bucket.
 
         :param bucket: bucket id or Bucket
         :return: Bucket
-                 If the method is called asynchronously,
-                 returns the request thread.
         """
         if isinstance(bucket, Bucket):
             bucket_id = bucket.id

--- a/influxdb_client/client/bucket_api.py
+++ b/influxdb_client/client/bucket_api.py
@@ -58,7 +58,7 @@ class BucketsApi(object):
 
         return self._buckets_service.post_buckets(post_bucket_request=bucket)
 
-    def update_bucket(self, bucket: Bucket):
+    def update_bucket(self, bucket: Bucket) -> Bucket:
         """Update a bucket.
 
         :param bucket: Bucket update to apply (required)

--- a/influxdb_client/client/organizations_api.py
+++ b/influxdb_client/client/organizations_api.py
@@ -4,8 +4,7 @@ An organization is a workspace for a group of users.
 All dashboards, tasks, buckets, members, etc., belong to an organization.
 """
 
-
-from influxdb_client import OrganizationsService, UsersService, Organization
+from influxdb_client import OrganizationsService, UsersService, Organization, PatchOrganizationRequest
 
 
 class OrganizationsApi(object):
@@ -44,6 +43,17 @@ class OrganizationsApi(object):
         if organization is None:
             organization = Organization(name=name)
         return self._organizations_service.post_orgs(post_organization_request=organization)
+
+    def update_organization(self, organization: Organization) -> Organization:
+        """Update an organization.
+
+        :param organization: Organization update to apply (required)
+        :return: Organization
+        """
+        request = PatchOrganizationRequest(name=organization.name,
+                                           description=organization.description)
+
+        return self._organizations_service.patch_orgs_id(org_id=organization.id, patch_organization_request=request)
 
     def delete_organization(self, org_id: str):
         """Delete an organization."""

--- a/influxdb_client/client/users_api.py
+++ b/influxdb_client/client/users_api.py
@@ -5,7 +5,8 @@ To grant a user permission to access data, add them as a member of an organizati
 and provide them with an authentication token.
 """
 
-from influxdb_client import UsersService, User
+from typing import Union
+from influxdb_client import UsersService, User, Users, UserResponse
 
 
 class UsersApi(object):
@@ -26,3 +27,39 @@ class UsersApi(object):
         user = User(name=name)
 
         return self._service.post_users(user=user)
+
+    def update_user(self, user: User) -> UserResponse:
+        """Update a user.
+
+        :param user: User update to apply (required)
+        :return: User
+        """
+        return self._service.patch_users_id(user_id=user.id, user=user)
+
+    def delete_user(self, user: Union[str, User, UserResponse]) -> None:
+        """Delete a user.
+
+        :param user: user id or User
+        :return: User
+        """
+        if isinstance(user, User):
+            user_id = user.id
+        elif isinstance(user, UserResponse):
+            user_id = user.id
+        else:
+            user_id = user
+
+        return self._service.delete_users_id(user_id=user_id)
+
+    def find_users(self, **kwargs) -> Users:
+        """List all users.
+
+        :key int offset: Offset for pagination
+        :key int limit: Limit for pagination
+        :key str after: The last resource ID from which to seek from (but not including).
+                        This is to be used instead of `offset`.
+        :key str name: The user name.
+        :key str id: The user ID.
+        :return: Buckets
+        """
+        return self._service.get_users(**kwargs)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -11,7 +11,11 @@ current_milli_time = lambda: int(round(time.time() * 1000))
 
 
 def generate_bucket_name():
-    return "test_bucket_" + str(datetime.datetime.now().timestamp()) + "_IT"
+    return generate_name(key="bucket")
+
+
+def generate_name(key: str):
+    return f"test_{key}_" + str(datetime.datetime.now().timestamp()) + "_IT"
 
 
 class BaseTest(unittest.TestCase):

--- a/tests/test_BucketsApi.py
+++ b/tests/test_BucketsApi.py
@@ -103,6 +103,18 @@ class BucketsClientTest(BaseTest):
         buckets = self.buckets_api.find_buckets(limit=1).buckets
         self.assertEqual(1, len(buckets))
 
+    def test_update_bucket(self):
+        my_org = self.find_my_org()
+
+        bucket = self.buckets_api.create_bucket(bucket_name=generate_bucket_name(),
+                                                org=my_org,
+                                                description="my description")
+        self.assertEqual("my description", bucket.description)
+
+        bucket.description = "updated description"
+        self.buckets_api.update_bucket(bucket=bucket)
+        self.assertEqual("updated description", bucket.description)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_OrganizationsApi.py
+++ b/tests/test_OrganizationsApi.py
@@ -1,0 +1,24 @@
+from tests.base_test import BaseTest, generate_name
+
+
+class OrganizationsApiTests(BaseTest):
+
+    def setUp(self) -> None:
+        super(OrganizationsApiTests, self).setUp()
+        organizations_api = self.client.organizations_api()
+        organizations = organizations_api.find_organizations()
+
+        for organization in organizations:
+            if organization.name.endswith("_IT"):
+                print("Delete organization: ", organization.name)
+                organizations_api.delete_organization(org_id=organization.id)
+
+    def test_update_organization(self):
+        organizations_api = self.client.organizations_api()
+
+        organization = organizations_api.create_organization(name=generate_name(key='org'))
+        self.assertEqual("", organization.description)
+
+        organization.description = "updated description"
+        organization = organizations_api.update_organization(organization=organization)
+        self.assertEqual("updated description", organization.description)

--- a/tests/test_UsersApi.py
+++ b/tests/test_UsersApi.py
@@ -1,0 +1,45 @@
+import pytest
+
+from influxdb_client import UserResponse
+from influxdb_client.rest import ApiException
+from tests.base_test import BaseTest, generate_name
+
+
+class UsersApiTests(BaseTest):
+
+    def setUp(self) -> None:
+        super(UsersApiTests, self).setUp()
+        users_api = self.client.users_api()
+        users = users_api.find_users()
+
+        for user in users.users:
+            if user.name.endswith("_IT"):
+                print("Delete user: ", user.name)
+                users_api.delete_user(user=user)
+
+    def test_delete_user(self):
+        users_api = self.client.users_api()
+
+        user = users_api.create_user(name=generate_name(key='user'))
+        users = users_api.find_users(id=user.id)
+        self.assertEqual(1, len(users.users))
+        self.assertEqual(user, users.users[0])
+
+        users_api.delete_user(user)
+
+        with pytest.raises(ApiException) as e:
+            assert users_api.find_users(id=user.id)
+        assert "user not found" in e.value.body
+
+    def test_update_user(self):
+        users_api = self.client.users_api()
+
+        name = generate_name(key='user')
+        user = users_api.create_user(name=name)
+        self.assertEqual(name, user.name)
+
+        user.name = "updated_" + name
+        user = users_api.update_user(user=user)
+        self.assertIsInstance(user, UserResponse)
+        user = users_api.find_users(id=user.id).users[0]
+        self.assertEqual("updated_" + name, user.name)


### PR DESCRIPTION
Closes #357 

## Proposed Changes

Updated management API:

- `BucketsApi` - add possibility to: `update`
- `OrganizationsApi` - add possibility to: `update`
- `UsersApi` - add possibility to: `update`, `delete`, `find`
    
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
