### PR TITLE
fix: construct InfluxDBError without http response

### DIFF
--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -12,9 +12,14 @@ class InfluxDBError(Exception):
 
     def __init__(self, response: HTTPResponse):
         """Initialize the InfluxDBError handler."""
-        self.response = response
-        self.message = self._get_message(response)
-        self.retry_after = response.getheader('Retry-After')
+        if response is not None:
+            self.response = response
+            self.message = self._get_message(response)
+            self.retry_after = response.getheader('Retry-After')
+        else:
+            self.response = None
+            self.message = 'response unavailable'
+            self.retry_after = None
         super().__init__(self.message)
 
     def _get_message(self, response):

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -18,7 +18,7 @@ class InfluxDBError(Exception):
             self.retry_after = response.getheader('Retry-After')
         else:
             self.response = None
-            self.message = 'response unavailable'
+            self.message = 'no response'
             self.retry_after = None
         super().__init__(self.message)
 

--- a/tests/test_InfluxDBError.py
+++ b/tests/test_InfluxDBError.py
@@ -46,3 +46,9 @@ class TestInfluxDBError(unittest.TestCase):
         influx_db_error = InfluxDBError(response=HTTPResponse(reason="too many requests"))
         self.assertEqual("too many requests", str(influx_db_error))
         self.assertEqual(None, influx_db_error.retry_after)
+
+    def test_no_response(self):
+        influx_db_error = InfluxDBError(response=None)
+        self.assertEqual("response unavailable", str(influx_db_error))
+        self.assertIsNone(influx_db_error.response)
+        self.assertIsNone(influx_db_error.retry_after)

--- a/tests/test_InfluxDBError.py
+++ b/tests/test_InfluxDBError.py
@@ -49,6 +49,6 @@ class TestInfluxDBError(unittest.TestCase):
 
     def test_no_response(self):
         influx_db_error = InfluxDBError(response=None)
-        self.assertEqual("response unavailable", str(influx_db_error))
+        self.assertEqual("no response", str(influx_db_error))
         self.assertIsNone(influx_db_error.response)
         self.assertIsNone(influx_db_error.retry_after)


### PR DESCRIPTION
## Proposed Changes

This fixes an AttributeError while handling another error raised from a failed POST request. In detail, when a POST request fails during the connection establishment there is no http response, so when an InfluxDBError instance is constructed the response field is None . This leads to an AttributeError later when the response.data is accessed. The fix is a trivial None check in the InfluxDBError constructor so that a None response argument properly works.

I was able to reproduce it due to the expired ssl certificate error with the following traceback (Python 3.10/Windows server 2016):

`  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connection.py", line 416, in connect
    self.sock = ssl_wrap_socket(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\util\ssl_.py", line 449, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\util\ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "C:\Python310\lib\ssl.py", line 512, in wrap_socket
    return self.sslsocket_class._create(
  File "C:\Python310\lib\ssl.py", line 1070, in _create
    self.do_handshake()
  File "C:\Python310\lib\ssl.py", line 1341, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\rest.py", line 217, in request
    r = self.pool_manager.request(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\request.py", line 78, in request
    return self.request_encode_body(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\request.py", line 170, in request_encode_body
    return self.urlopen(method, url, **extra_kw)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\poolmanager.py", line 375, in urlopen
    response = conn.urlopen(method, u.request_uri, **kw)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\util\retry.py", line 507, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\packages\six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connectionpool.py", line 1010, in _validate_conn
    conn.connect()
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\connection.py", line 416, in connect
    self.sock = ssl_wrap_socket(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\util\ssl_.py", line 449, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "C:\dev\python_env\prod\lib\site-packages\urllib3\util\ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "C:\Python310\lib\ssl.py", line 512, in wrap_socket
    return self.sslsocket_class._create(
  File "C:\Python310\lib\ssl.py", line 1070, in _create
    self.do_handshake()
  File "C:\Python310\lib\ssl.py", line 1341, in do_handshake
    self._sslobj.do_handshake()
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\dev\coinbot\src\coinbot\rolling_iv\main.py", line 16, in amain
    await script_func(cancel_token)
  File "C:\dev\coinbot\src\coinbot\rolling_iv\rolling_iv.py", line 299, in periodic_compute
    persist(pivots_tbl, next_time, coin)
  File "C:\dev\python_env\prod\lib\site-packages\tenacity\__init__.py", line 324, in wrapped_f
    return self(f, *args, **kw)
  File "C:\dev\python_env\prod\lib\site-packages\tenacity\__init__.py", line 404, in __call__
    do = self.iter(retry_state=retry_state)
  File "C:\dev\python_env\prod\lib\site-packages\tenacity\__init__.py", line 360, in iter
    raise retry_exc.reraise()
  File "C:\dev\python_env\prod\lib\site-packages\tenacity\__init__.py", line 193, in reraise
    raise self.last_attempt.result()
  File "C:\Python310\lib\concurrent\futures\_base.py", line 438, in result
    return self.__get_result()
  File "C:\Python310\lib\concurrent\futures\_base.py", line 390, in __get_result
    raise self._exception
  File "C:\dev\python_env\prod\lib\site-packages\tenacity\__init__.py", line 407, in __call__
    result = fn(*args, **kwargs)
  File "C:\dev\coinbot\src\coinbot\rolling_iv\rolling_iv.py", line 266, in persist
    write_api.write(_influx_bucket, _influx_org, points)
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\client\write_api.py", line 371, in write
    results = list(map(write_payload, payloads.items()))
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\client\write_api.py", line 369, in write_payload
    return self._post_write(_async_req, bucket, org, final_string, payload[0])
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\client\write_api.py", line 517, in _post_write
    return self._write_service.post_write(org=org, bucket=bucket, body=body, precision=precision,
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\service\write_service.py", line 62, in post_write
    (data) = self.post_write_with_http_info(org, bucket, body, **kwargs)  # noqa: E501
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\service\write_service.py", line 166, in post_write_with_http_info
    return self.api_client.call_api(
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\api_client.py", line 341, in call_api
    return self.__call_api(resource_path, method,
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\api_client.py", line 171, in __call_api
    response_data = self.request(
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\api_client.py", line 386, in request
    return self.rest_client.POST(url,
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\rest.py", line 304, in POST
    return self.request("POST", url,
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\rest.py", line 240, in request
    raise ApiException(status=0, reason=msg)
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\rest.py", line 360, in __init__
    super().__init__(response=http_resp)
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\client\exceptions.py", line 16, in __init__
    self.message = self._get_message(response)
  File "C:\dev\python_env\prod\lib\site-packages\influxdb_client\client\exceptions.py", line 22, in _get_message
    if response.data:
AttributeError: 'NoneType' object has no attribute 'data'`

## Checklist

- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
