### PR TITLE
fix: serialization to DataFrame with nan values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#375](https://github.com/influxdata/influxdb-client-python/pull/375): Construct `InfluxDBError` without HTTP response 
+1. [#378](https://github.com/influxdata/influxdb-client-python/pull/378): Correct serialization DataFrame with nan values [DataFrame]
 
 ### CI
 1. [#370](https://github.com/influxdata/influxdb-client-python/pull/370): Add Python 3.10 to CI builds

--- a/influxdb_client/client/write/dataframe_serializer.py
+++ b/influxdb_client/client/write/dataframe_serializer.py
@@ -27,9 +27,6 @@ def _any_not_nan(p, indexes):
     return any(map(lambda x: _not_nan(p[x]), indexes))
 
 
-_EMPTY_EXPRESSION = "_EMPTY_LINE_PROTOCOL_PART_"
-
-
 class DataframeSerializer:
     """Serialize DataFrame into LineProtocols."""
 
@@ -180,15 +177,13 @@ class DataframeSerializer:
                 field_value = f'{sep}{key_format}={{{val_format}}}'
             elif issubclass(value.type, np.floating):
                 if null_columns[index]:
-                    field_value = f"""{{
-                    "{sep}{_EMPTY_EXPRESSION}" if math.isnan({val_format}) else f"{sep}{key_format}={{{val_format}}}"
-                    }}"""
+                    field_value = f"""{{"" if math.isnan({val_format}) else f"{sep}{key_format}={{{val_format}}}"}}"""
                 else:
                     field_value = f'{sep}{key_format}={{{val_format}}}'
             else:
                 if null_columns[index]:
                     field_value = f"""{{
-                            '{sep}{_EMPTY_EXPRESSION}' if type({val_format}) == float and math.isnan({val_format}) else
+                            '' if type({val_format}) == float and math.isnan({val_format}) else
                             f'{sep}{key_format}="{{str({val_format}).translate(_ESCAPE_STRING)}}"'
                         }}"""
                 else:
@@ -249,7 +244,7 @@ class DataframeSerializer:
         if self.first_field_maybe_null:
             # When the first field is null (None/NaN), we'll have
             # a spurious leading comma which needs to be removed.
-            lp = (re.sub(f",{_EMPTY_EXPRESSION}|{_EMPTY_EXPRESSION},|{_EMPTY_EXPRESSION}", '', self.f(p))
+            lp = (re.sub('^(( |[^ ])* ),([a-zA-Z])(.*)', '\\1\\3\\4', self.f(p))
                   for p in filter(lambda x: _any_not_nan(x, self.field_indexes), _itertuples(chunk)))
             return list(lp)
         else:

--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -408,8 +408,10 @@ Date;Entry Type;Value;Currencs;Category;Person;Account;Counter Account;Group;Not
                                               data_frame_measurement_name="test",
                                               point_settings=PointSettings())
 
+        self.assertEqual(3, len(points))
         self.assertEqual("test a=0.0,b=0.0 1609459200000000000", points[0])
         self.assertEqual("test a=1.0 1609459260000000000", points[1])
+        self.assertEqual("test a=2.0,b=1.0 1609459320000000000", points[2])
 
 
 class DataSerializerChunksTest(unittest.TestCase):

--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -396,6 +396,21 @@ Date;Entry Type;Value;Currencs;Category;Person;Account;Counter Account;Group;Not
         self.assertEqual("bookings,Account=Testaccount,Category=Testcategory,Entry\\ Type=Expense Currencs=\"EUR\",Note=\"This, works\",Recurring=\"no\",Value=-1.0 1538352000000000000", points[0])
         self.assertEqual("bookings,Account=Testaccount,Category=Testcategory,Entry\\ Type=Expense Currencs=\"EUR\",Note=\"This , works not\",Recurring=\"no\",Value=-1.0 1538438400000000000", points[1])
 
+    def test_without_tags_and_fields_with_nan(self):
+        from influxdb_client.extras import pd, np
+
+        df = pd.DataFrame({
+            'a': np.arange(0., 3.),
+            'b': [0., np.nan, 1.],
+        }).set_index(pd.to_datetime(['2021-01-01 0:00', '2021-01-01 0:01', '2021-01-01 0:02']))
+
+        points = data_frame_to_list_of_points(data_frame=df,
+                                              data_frame_measurement_name="test",
+                                              point_settings=PointSettings())
+
+        self.assertEqual("test a=0.0,b=0.0 1609459200000000000", points[0])
+        self.assertEqual("test a=1.0 1609459260000000000", points[1])
+
 
 class DataSerializerChunksTest(unittest.TestCase):
     def test_chunks(self):


### PR DESCRIPTION
Closes #377

## Proposed Changes

1. Rollback regression caused by https://github.com/influxdata/influxdb-client-python/commit/500835f3b1d3b2b87214ede830b750a6018c0ca9#diff-02179d31a524332a9b64b57d464f6a56c0725daf636a4a410a20ed2aa71a43e0
2. Improve regex to match start field with null value

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
