### PR TITLE
fix: timeout can be specified as a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 1. [#375](https://github.com/influxdata/influxdb-client-python/pull/375): Construct `InfluxDBError` without HTTP response 
 1. [#378](https://github.com/influxdata/influxdb-client-python/pull/378): Correct serialization DataFrame with nan values [DataFrame]
+1. [#384](https://github.com/influxdata/influxdb-client-python/pull/384): Timeout can be specified as a `float`
 
 ### CI
 1. [#370](https://github.com/influxdata/influxdb-client-python/pull/370): Add Python 3.10 to CI builds

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -161,7 +161,7 @@ class RESTClientObject(object):
         timeout = None
         _configured_timeout = _request_timeout or self.configuration.timeout
         if _configured_timeout:
-            if isinstance(_configured_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
+            if isinstance(_configured_timeout, (int, float, ) if six.PY3 else (int, long, float, )):  # noqa: E501,F821
                 timeout = urllib3.Timeout(total=_configured_timeout / 1_000)
             elif (isinstance(_configured_timeout, tuple) and
                   len(_configured_timeout) == 2):


### PR DESCRIPTION
Closes #383

## Proposed Changes

Timeout can be specified as a float.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
