### PR TITLE
fix: multiple dataframes for tables with different schema

### DIFF
--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -131,7 +131,8 @@ class QueryApi(object):
         """
         Execute synchronous Flux query and return Pandas DataFrame.
 
-        Note that if a query returns more then one table than the client generates a DataFrame for each of them.
+        Note that if a query returns tables with differing schemas than the client generates
+        a DataFrame for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
@@ -157,7 +158,8 @@ class QueryApi(object):
         """
         Execute synchronous Flux query and return stream of Pandas DataFrame as a Generator['pd.DataFrame'].
 
-        Note that if a query returns more then one table than the client generates a DataFrame for each of them.
+        Note that if a query returns tables with differing schemas than the client generates
+        a DataFrame for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;


### PR DESCRIPTION
Related to https://community.influxdata.com/t/python-client-query-data-frame-does-not-return-multiple-dataframes/22955

## Proposed Changes

The multiple DataFrames are return when there are tables with different schema.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
