### PR TITLE
feat: add InvocableScripts API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Features
 1. [#412](https://github.com/influxdata/influxdb-client-python/pull/412): `DeleteApi` uses default value from `InfluxDBClient.org` if an `org` parameter is not specified
-2. [#405](https://github.com/influxdata/influxdb-client-python/pull/405): Add `InfluxLoggingHandler`. A handler to use the client in native python logging.
+1. [#405](https://github.com/influxdata/influxdb-client-python/pull/405): Add `InfluxLoggingHandler`. A handler to use the client in native python logging.
+1. [#404](https://github.com/influxdata/influxdb-client-python/pull/404): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
 
 ### CI
 1. [#411](https://github.com/influxdata/influxdb-client-python/pull/411): Use new Codecov uploader for reporting code coverage
@@ -46,11 +47,10 @@ This release introduces a support for new version of InfluxDB OSS API definition
 1. [#408](https://github.com/influxdata/influxdb-client-python/pull/408): Improve error message when the client cannot find organization by name
 1. [#407](https://github.com/influxdata/influxdb-client-python/pull/407): Use `pandas.concat()` instead of deprecated `DataFrame.append()` [DataFrame]
 
- 
 ## 1.25.0 [2022-01-20]
 
 ### Features
-1. [#393](https://github.com/influxdata/influxdb-client-python/pull/393): Added callback function for getting profilers output with example and test
+1. [#393](https://github.com/influxdata/influxdb-client-python/pull/393): Add callback function for getting profilers output with example and test
 
 ### Bug Fixes
 1. [#375](https://github.com/influxdata/influxdb-client-python/pull/375): Construct `InfluxDBError` without HTTP response 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,6 +62,17 @@ TasksApi
 .. autoclass:: influxdb_client.domain.Task
    :members:
 
+InvocableScriptsApi
+"""""""""""""""""""
+.. autoclass:: influxdb_client.InvocableScriptsApi
+   :members:
+
+.. autoclass:: influxdb_client.domain.Script
+   :members:
+
+.. autoclass:: influxdb_client.domain.ScriptCreateRequest
+   :members:
+
 DeleteApi
 """""""""
 .. autoclass:: influxdb_client.DeleteApi

--- a/examples/invocable_scripts.py
+++ b/examples/invocable_scripts.py
@@ -56,6 +56,16 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     """
     Invoke a script
     """
+    # FluxRecords
+    print(f"\n------- Invoke to FluxRecords -------\n")
+    tables = scripts_api.invoke_scripts(script_id=created_script.id, params={"bucket_name": bucket_name})
+    for table in tables:
+        for record in table.records:
+            print(f'FluxRecord {record}')
+    # Pandas DataFrame
+    print(f"\n------- Invoke to PandasData Frame -------\n")
+    data_frame = scripts_api.invoke_scripts_data_frame(script_id=created_script.id, params={"bucket_name": bucket_name})
+    print(data_frame.to_string())
     # CSV
     print(f"\n------- Invoke to CSV-------\n")
     csv_lines = scripts_api.invoke_scripts_csv(script_id=created_script.id, params={"bucket_name": bucket_name})

--- a/examples/invocable_scripts.py
+++ b/examples/invocable_scripts.py
@@ -27,10 +27,9 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     Create Invocable Script
     """
     print(f"------- Create -------\n")
-    create_request = ScriptCreateRequest(name=f"my_scrupt_{uniqueId}",
+    create_request = ScriptCreateRequest(name=f"my_script_{uniqueId}",
                                          description="my first try",
                                          language=ScriptLanguage.FLUX,
-                                         org_id=org.id,
                                          script=f"from(bucket: params.bucket_name) |> range(start: -30d) |> limit(n:2)")
 
     created_script = scripts_service.post_scripts(script_create_request=create_request)

--- a/examples/invocable_scripts.py
+++ b/examples/invocable_scripts.py
@@ -22,6 +22,7 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     org = client.organizations_api().find_organizations(org=org_name)[0]
 
     scripts_service = InvocableScriptsService(api_client=client.api_client)
+    scripts_api = client.invocable_scripts_api()
 
     """
     Create Invocable Script
@@ -32,7 +33,7 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
                                          language=ScriptLanguage.FLUX,
                                          script=f"from(bucket: params.bucket_name) |> range(start: -30d) |> limit(n:2)")
 
-    created_script = scripts_service.post_scripts(script_create_request=create_request)
+    created_script = scripts_api.create_script(create_request=create_request)
     print(created_script)
 
     """
@@ -48,7 +49,7 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     List scripts
     """
     print(f"\n------- List -------\n")
-    scripts = scripts_service.get_scripts().scripts
+    scripts = scripts_api.find_scripts()
     print("\n".join([f" ---\n ID: {it.id}\n Name: {it.name}\n Description: {it.description}" for it in scripts]))
     print("---")
 
@@ -56,5 +57,5 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     Delete previously created Script
     """
     print(f"------- Delete -------\n")
-    scripts_service.delete_scripts_id(script_id=created_script.id)
+    scripts_api.delete_script(script_id=created_script.id)
     print(f" Successfully deleted script: '{created_script.name}'")

--- a/examples/invocable_scripts.py
+++ b/examples/invocable_scripts.py
@@ -4,7 +4,7 @@ How to use Invocable scripts Cloud API to create custom endpoints that query dat
 import datetime
 
 from influxdb_client import InfluxDBClient, InvocableScriptsService, ScriptCreateRequest, ScriptInvocationParams, \
-    ScriptLanguage
+    ScriptLanguage, ScriptUpdateRequest
 
 """
 Define credentials
@@ -34,6 +34,14 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
                                          script=f"from(bucket: params.bucket_name) |> range(start: -30d) |> limit(n:2)")
 
     created_script = scripts_api.create_script(create_request=create_request)
+    print(created_script)
+
+    """
+    Update Invocable Script
+    """
+    print(f"------- Update -------\n")
+    update_request = ScriptUpdateRequest(description="my updated description")
+    created_script = scripts_api.update_script(script_id=created_script.id, update_request=update_request)
     print(created_script)
 
     """

--- a/examples/invocable_scripts.py
+++ b/examples/invocable_scripts.py
@@ -3,7 +3,7 @@ How to use Invocable scripts Cloud API to create custom endpoints that query dat
 """
 import datetime
 
-from influxdb_client import InfluxDBClient, InvocableScriptsService, ScriptCreateRequest, ScriptLanguage, \
+from influxdb_client import InfluxDBClient, ScriptCreateRequest, ScriptLanguage, \
     ScriptUpdateRequest, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 
@@ -31,7 +31,6 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token, org=org_name
     """
     org = client.organizations_api().find_organizations(org=org_name)[0]
 
-    scripts_service = InvocableScriptsService(api_client=client.api_client)
     scripts_api = client.invocable_scripts_api()
 
     """

--- a/examples/query.py
+++ b/examples/query.py
@@ -3,7 +3,7 @@ import datetime as datetime
 from influxdb_client import InfluxDBClient, Point, Dialect
 from influxdb_client.client.write_api import SYNCHRONOUS
 
-with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org",debug=True) as client:
+with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org", debug=False) as client:
 
     write_api = client.write_api(write_options=SYNCHRONOUS)
 

--- a/influxdb_client/__init__.py
+++ b/influxdb_client/__init__.py
@@ -376,6 +376,7 @@ from influxdb_client.domain.xy_view_properties import XYViewProperties
 from influxdb_client.client.authorizations_api import AuthorizationsApi
 from influxdb_client.client.bucket_api import BucketsApi
 from influxdb_client.client.delete_api import DeleteApi
+from influxdb_client.client.invocable_scripts_api import InvocableScriptsApi
 from influxdb_client.client.labels_api import LabelsApi
 from influxdb_client.client.organizations_api import OrganizationsApi
 from influxdb_client.client.query_api import QueryApi

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -8,7 +8,8 @@ import os
 import base64
 import warnings
 
-from influxdb_client import Configuration, ApiClient, HealthCheck, HealthService, Ready, ReadyService, PingService
+from influxdb_client import Configuration, ApiClient, HealthCheck, HealthService, Ready, ReadyService, PingService, \
+    InvocableScriptsApi
 from influxdb_client.client.authorizations_api import AuthorizationsApi
 from influxdb_client.client.bucket_api import BucketsApi
 from influxdb_client.client.delete_api import DeleteApi
@@ -337,12 +338,20 @@ class InfluxDBClient(object):
 
     def query_api(self, query_options: QueryOptions = QueryOptions()) -> QueryApi:
         """
-        Create a Query API instance.
+        Create an Query API instance.
 
         :param query_options: optional query api configuration
         :return: Query api instance
         """
         return QueryApi(self, query_options)
+
+    def invocable_scripts_api(self) -> InvocableScriptsApi:
+        """
+        Create an InvocableScripts API instance.
+
+        :return: InvocableScripts API instance
+        """
+        return InvocableScriptsApi(self)
 
     def close(self):
         """Shutdown the client."""

--- a/influxdb_client/client/invocable_scripts_api.py
+++ b/influxdb_client/client/invocable_scripts_api.py
@@ -5,10 +5,15 @@ API invokable scripts let you assign scripts to API endpoints and then execute t
 in InfluxDB Cloud.
 """
 
-from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest, ScriptUpdateRequest
+from typing import List, Iterator, Generator, Any
+
+from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest, ScriptUpdateRequest, \
+    ScriptInvocationParams
+from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.queryable_api import QueryableApi
 
 
-class InvocableScriptsApi(object):
+class InvocableScriptsApi(QueryableApi):
     """Use API invokable scripts to create custom InfluxDB API endpoints that query, process, and shape data."""
 
     def __init__(self, influxdb_client):
@@ -51,3 +56,119 @@ class InvocableScriptsApi(object):
         :rtype: list[Script]
         """
         return self._invocable_scripts_service.get_scripts(**kwargs).scripts
+
+    def invoke_scripts(self, script_id: str, params: dict = None) -> List['FluxTable']:
+        """
+        Invoke synchronously a script and return result as a List['FluxTable'].
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param params: bind parameters
+        :return: List of FluxTable.
+        :rtype: list[FluxTable]
+        """
+        response = self._invocable_scripts_service \
+            .post_scripts_id_invoke(script_id=script_id,
+                                    script_invocation_params=ScriptInvocationParams(params=params),
+                                    async_req=False,
+                                    _preload_content=False,
+                                    _return_http_data_only=False)
+        return self._to_tables(response, query_options=None)
+
+    def invoke_scripts_stream(self, script_id: str, params: dict = None) -> Generator['FluxRecord', Any, None]:
+        """
+        Invoke synchronously a script and return result as a Generator['FluxRecord'].
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param params: bind parameters
+        :return: Stream of FluxRecord.
+        :rtype: Generator['FluxRecord']
+        """
+        response = self._invocable_scripts_service \
+            .post_scripts_id_invoke(script_id=script_id,
+                                    script_invocation_params=ScriptInvocationParams(params=params),
+                                    async_req=False,
+                                    _preload_content=False,
+                                    _return_http_data_only=False)
+
+        return self._to_flux_record_stream(response, query_options=None)
+
+    def invoke_scripts_data_frame(self, script_id: str, params: dict = None, data_frame_index: List[str] = None):
+        """
+        Invoke synchronously a script and return Pandas DataFrame.
+
+        Note that if a script returns tables with differing schemas than the client generates
+        a DataFrame for each of them.
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param List[str] data_frame_index: The list of columns that are used as DataFrame index.
+        :param params: bind parameters
+        :return: Pandas DataFrame.
+        """
+        _generator = self.invoke_scripts_data_frame_stream(script_id=script_id,
+                                                           params=params,
+                                                           data_frame_index=data_frame_index)
+        return self._to_data_frames(_generator)
+
+    def invoke_scripts_data_frame_stream(self, script_id: str, params: dict = None, data_frame_index: List[str] = None):
+        """
+        Invoke synchronously a script and return stream of Pandas DataFrame as a Generator['pd.DataFrame'].
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param List[str] data_frame_index: The list of columns that are used as DataFrame index.
+        :param params: bind parameters
+        :return: Stream of Pandas DataFrames.
+        :rtype: Generator['pd.DataFrame']
+        """
+        response = self._invocable_scripts_service \
+            .post_scripts_id_invoke(script_id=script_id,
+                                    script_invocation_params=ScriptInvocationParams(params=params),
+                                    async_req=False,
+                                    _preload_content=False,
+                                    _return_http_data_only=False)
+
+        return self._to_data_frame_stream(data_frame_index, response, query_options=None)
+
+    def invoke_scripts_csv(self, script_id: str, params: dict = None) -> Iterator[List[str]]:
+        """
+        Invoke synchronously a script and return result as a CSV iterator.
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param params: bind parameters
+        :return: The returned object is an iterator. Each iteration returns a row of the CSV file
+                 (which can span multiple input lines).
+        """
+        response = self._invocable_scripts_service \
+            .post_scripts_id_invoke(script_id=script_id,
+                                    script_invocation_params=ScriptInvocationParams(params=params),
+                                    async_req=False,
+                                    _preload_content=False)
+
+        return self._to_csv(response)
+
+    def invoke_scripts_raw(self, script_id: str, params: dict = None) -> Iterator[List[str]]:
+        """
+        Invoke synchronously a script and return result as raw unprocessed result as a str.
+
+        The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        :param str script_id: The ID of the script to invoke. (required)
+        :param params: bind parameters
+        :return: Result as a str.
+        """
+        response = self._invocable_scripts_service \
+            .post_scripts_id_invoke(script_id=script_id,
+                                    script_invocation_params=ScriptInvocationParams(params=params),
+                                    async_req=False,
+                                    _preload_content=True)
+
+        return response

--- a/influxdb_client/client/invocable_scripts_api.py
+++ b/influxdb_client/client/invocable_scripts_api.py
@@ -9,6 +9,7 @@ from typing import List, Iterator, Generator, Any
 
 from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest, ScriptUpdateRequest, \
     ScriptInvocationParams
+from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode
 from influxdb_client.client.flux_table import FluxTable, FluxRecord
 from influxdb_client.client.queryable_api import QueryableApi
 
@@ -74,7 +75,7 @@ class InvocableScriptsApi(QueryableApi):
                                     async_req=False,
                                     _preload_content=False,
                                     _return_http_data_only=False)
-        return self._to_tables(response, query_options=None)
+        return self._to_tables(response, query_options=None, response_metadata_mode=FluxResponseMetadataMode.only_names)
 
     def invoke_scripts_stream(self, script_id: str, params: dict = None) -> Generator['FluxRecord', Any, None]:
         """
@@ -94,7 +95,8 @@ class InvocableScriptsApi(QueryableApi):
                                     _preload_content=False,
                                     _return_http_data_only=False)
 
-        return self._to_flux_record_stream(response, query_options=None)
+        return self._to_flux_record_stream(response, query_options=None,
+                                           response_metadata_mode=FluxResponseMetadataMode.only_names)
 
     def invoke_scripts_data_frame(self, script_id: str, params: dict = None, data_frame_index: List[str] = None):
         """
@@ -134,7 +136,8 @@ class InvocableScriptsApi(QueryableApi):
                                     _preload_content=False,
                                     _return_http_data_only=False)
 
-        return self._to_data_frame_stream(data_frame_index, response, query_options=None)
+        return self._to_data_frame_stream(data_frame_index, response, query_options=None,
+                                          response_metadata_mode=FluxResponseMetadataMode.only_names)
 
     def invoke_scripts_csv(self, script_id: str, params: dict = None) -> Iterator[List[str]]:
         """

--- a/influxdb_client/client/invocable_scripts_api.py
+++ b/influxdb_client/client/invocable_scripts_api.py
@@ -5,7 +5,7 @@ API invokable scripts let you assign scripts to API endpoints and then execute t
 in InfluxDB Cloud.
 """
 
-from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest
+from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest, ScriptUpdateRequest
 
 
 class InvocableScriptsApi(object):
@@ -23,6 +23,16 @@ class InvocableScriptsApi(object):
         :return: The created script.
         """
         return self._invocable_scripts_service.post_scripts(script_create_request=create_request)
+
+    def update_script(self, script_id: str, update_request: ScriptUpdateRequest) -> Script:
+        """Update a script.
+
+        :param str script_id: The ID of the script to update. (required)
+        :param ScriptUpdateRequest update_request: Script updates to apply (required)
+        :return: The updated.
+        """
+        return self._invocable_scripts_service.patch_scripts_id(script_id=script_id,
+                                                                script_update_request=update_request)
 
     def delete_script(self, script_id: str) -> None:
         """Delete a script.

--- a/influxdb_client/client/invocable_scripts_api.py
+++ b/influxdb_client/client/invocable_scripts_api.py
@@ -23,3 +23,21 @@ class InvocableScriptsApi(object):
         :return: The created script.
         """
         return self._invocable_scripts_service.post_scripts(script_create_request=create_request)
+
+    def delete_script(self, script_id: str) -> None:
+        """Delete a script.
+
+        :param str script_id: The ID of the script to delete. (required)
+        :return: None
+        """
+        self._invocable_scripts_service.delete_scripts_id(script_id=script_id)
+
+    def find_scripts(self, **kwargs):
+        """List scripts.
+
+        :key int limit: The number of scripts to return.
+        :key int offset: The offset for pagination.
+        :return: List of scripts.
+        :rtype: list[Script]
+        """
+        return self._invocable_scripts_service.get_scripts(**kwargs).scripts

--- a/influxdb_client/client/invocable_scripts_api.py
+++ b/influxdb_client/client/invocable_scripts_api.py
@@ -1,0 +1,25 @@
+"""
+Use API invokable scripts to create custom InfluxDB API endpoints that query, process, and shape data.
+
+API invokable scripts let you assign scripts to API endpoints and then execute them as standard REST operations
+in InfluxDB Cloud.
+"""
+
+from influxdb_client import Script, InvocableScriptsService, ScriptCreateRequest
+
+
+class InvocableScriptsApi(object):
+    """Use API invokable scripts to create custom InfluxDB API endpoints that query, process, and shape data."""
+
+    def __init__(self, influxdb_client):
+        """Initialize defaults."""
+        self._influxdb_client = influxdb_client
+        self._invocable_scripts_service = InvocableScriptsService(influxdb_client.api_client)
+
+    def create_script(self, create_request: ScriptCreateRequest) -> Script:
+        """Create a script.
+
+        :param ScriptCreateRequest create_request: The script to create. (required)
+        :return: The created script.
+        """
+        return self._invocable_scripts_service.post_scripts(script_create_request=create_request)

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -5,7 +5,7 @@ Flux is InfluxData’s functional data scripting language designed for querying,
 """
 
 from datetime import datetime, timedelta
-from typing import List, Generator, Any, Union, Iterable, Callable, Iterator
+from typing import List, Generator, Any, Union, Iterable, Callable
 
 from influxdb_client import Dialect, IntegerLiteral, BooleanLiteral, FloatLiteral, DateTimeLiteral, StringLiteral, \
     VariableAssignment, Identifier, OptionStatement, File, DurationLiteral, Duration, UnaryExpression, Expression, \

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -4,17 +4,15 @@ Querying InfluxDB bu FluxLang.
 Flux is InfluxData’s functional data scripting language designed for querying, analyzing, and acting on data.
 """
 
-import codecs
-import csv
 from datetime import datetime, timedelta
-from typing import List, Generator, Any, Union, Iterable, Callable
+from typing import List, Generator, Any, Union, Iterable, Callable, Iterator
 
 from influxdb_client import Dialect, IntegerLiteral, BooleanLiteral, FloatLiteral, DateTimeLiteral, StringLiteral, \
     VariableAssignment, Identifier, OptionStatement, File, DurationLiteral, Duration, UnaryExpression, Expression, \
     ImportDeclaration, MemberAssignment, MemberExpression, ArrayExpression
 from influxdb_client import Query, QueryService
-from influxdb_client.client.flux_csv_parser import FluxCsvParser, FluxSerializationMode
 from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.queryable_api import QueryableApi
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.client.util.helpers import get_org_query_param
 
@@ -33,7 +31,7 @@ class QueryOptions(object):
         self.profiler_callback = profiler_callback
 
 
-class QueryApi(object):
+class QueryApi(QueryableApi):
     """Implementation for '/api/v2/query' endpoint."""
 
     default_dialect = Dialect(header=True, delimiter=",", comment_prefix="#",
@@ -59,14 +57,14 @@ class QueryApi(object):
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param dialect: csv dialect format
         :param params: bind parameters
-        :return: The returned object is an iterator.  Each iteration returns a row of the CSV file
+        :return: The returned object is an iterator. Each iteration returns a row of the CSV file
                  (which can span multiple input lines).
         """
         org = self._org_param(org)
         response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params),
                                               async_req=False, _preload_content=False)
 
-        return csv.reader(codecs.iterdecode(response, 'utf-8'))
+        return self._to_csv(response)
 
     def query_raw(self, query: str, org=None, dialect=default_dialect, params: dict = None):
         """
@@ -102,12 +100,7 @@ class QueryApi(object):
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
 
-        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.tables,
-                                query_options=self._get_query_options())
-
-        list(_parser.generator())
-
-        return _parser.table_list()
+        return self._to_tables(response, query_options=self._get_query_options())
 
     def query_stream(self, query: str, org=None, params: dict = None) -> Generator['FluxRecord', Any, None]:
         """
@@ -124,10 +117,7 @@ class QueryApi(object):
 
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
-        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.stream,
-                                query_options=self._get_query_options())
-
-        return _parser.generator()
+        return self._to_flux_record_stream(response, query_options=self._get_query_options())
 
     def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
         """
@@ -144,17 +134,8 @@ class QueryApi(object):
         :param params: bind parameters
         :return:
         """
-        from ..extras import pd
-
         _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index, params=params)
-        _dataFrames = list(_generator)
-
-        if len(_dataFrames) == 0:
-            return pd.DataFrame(columns=[], index=None)
-        elif len(_dataFrames) == 1:
-            return _dataFrames[0]
-        else:
-            return _dataFrames
+        return self._to_data_frames(_generator)
 
     def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
         """
@@ -176,10 +157,9 @@ class QueryApi(object):
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
 
-        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.dataFrame,
-                                data_frame_index=data_frame_index,
-                                query_options=self._get_query_options())
-        return _parser.generator()
+        return self._to_data_frame_stream(data_frame_index=data_frame_index,
+                                          response=response,
+                                          query_options=self._get_query_options())
 
     def _get_query_options(self):
         if self._query_options and self._query_options.profilers:

--- a/influxdb_client/client/queryable_api.py
+++ b/influxdb_client/client/queryable_api.py
@@ -1,0 +1,49 @@
+"""Helper to share queryable function between APIs - query_api, invocable_scripts_api."""
+import codecs
+import csv
+from typing import List, Iterator, Generator, Any
+
+from urllib3 import HTTPResponse
+
+from influxdb_client.client.flux_csv_parser import FluxCsvParser, FluxSerializationMode
+from influxdb_client.client.flux_table import FluxTable, FluxRecord
+
+
+# noinspection PyMethodMayBeStatic
+class QueryableApi(object):
+    """Base implementation for Queryable API."""
+
+    def _to_tables(self, response: HTTPResponse, query_options=None) -> List[FluxTable]:
+        """Parse HTTP response to FluxTables."""
+        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.tables,
+                                query_options=query_options)
+        list(_parser.generator())
+        return _parser.table_list()
+
+    def _to_csv(self, response: HTTPResponse) -> Iterator[List[str]]:
+        """Parse HTTP response to CSV."""
+        return csv.reader(codecs.iterdecode(response, 'utf-8'))
+
+    def _to_flux_record_stream(self, response, query_options=None) -> Generator['FluxRecord', Any, None]:
+        """Parse HTTP response to FluxRecord stream."""
+        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.stream,
+                                query_options=query_options)
+        return _parser.generator()
+
+    def _to_data_frame_stream(self, data_frame_index, response, query_options=None):
+        """Parse HTTP response to DataFrame stream."""
+        _parser = FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.dataFrame,
+                                data_frame_index=data_frame_index,
+                                query_options=query_options)
+        return _parser.generator()
+
+    def _to_data_frames(self, _generator):
+        """Parse stream of DataFrames into expected type."""
+        from ..extras import pd
+        _dataFrames = list(_generator)
+        if len(_dataFrames) == 0:
+            return pd.DataFrame(columns=[], index=None)
+        elif len(_dataFrames) == 1:
+            return _dataFrames[0]
+        else:
+            return _dataFrames

--- a/influxdb_client/domain/authorization.py
+++ b/influxdb_client/domain/authorization.py
@@ -139,7 +139,7 @@ class Authorization(AuthorizationUpdateRequest):
     def org_id(self):
         """Get the org_id of this Authorization.
 
-        ID of org that authorization is scoped to.
+        ID of the organization that the authorization is scoped to.
 
         :return: The org_id of this Authorization.
         :rtype: str
@@ -150,7 +150,7 @@ class Authorization(AuthorizationUpdateRequest):
     def org_id(self, org_id):
         """Set the org_id of this Authorization.
 
-        ID of org that authorization is scoped to.
+        ID of the organization that the authorization is scoped to.
 
         :param org_id: The org_id of this Authorization.
         :type: str
@@ -161,7 +161,7 @@ class Authorization(AuthorizationUpdateRequest):
     def permissions(self):
         """Get the permissions of this Authorization.
 
-        List of permissions for an auth.  An auth must have at least one Permission.
+        List of permissions for an authorization.  An authorization must have at least one permission.
 
         :return: The permissions of this Authorization.
         :rtype: list[Permission]
@@ -172,7 +172,7 @@ class Authorization(AuthorizationUpdateRequest):
     def permissions(self, permissions):
         """Set the permissions of this Authorization.
 
-        List of permissions for an auth.  An auth must have at least one Permission.
+        List of permissions for an authorization.  An authorization must have at least one permission.
 
         :param permissions: The permissions of this Authorization.
         :type: list[Permission]
@@ -201,7 +201,7 @@ class Authorization(AuthorizationUpdateRequest):
     def token(self):
         """Get the token of this Authorization.
 
-        Passed via the Authorization Header and Token Authentication type.
+        Token used to authenticate API requests.
 
         :return: The token of this Authorization.
         :rtype: str
@@ -212,7 +212,7 @@ class Authorization(AuthorizationUpdateRequest):
     def token(self, token):
         """Set the token of this Authorization.
 
-        Passed via the Authorization Header and Token Authentication type.
+        Token used to authenticate API requests.
 
         :param token: The token of this Authorization.
         :type: str
@@ -223,7 +223,7 @@ class Authorization(AuthorizationUpdateRequest):
     def user_id(self):
         """Get the user_id of this Authorization.
 
-        ID of user that created and owns the token.
+        ID of the user that created and owns the token.
 
         :return: The user_id of this Authorization.
         :rtype: str
@@ -234,7 +234,7 @@ class Authorization(AuthorizationUpdateRequest):
     def user_id(self, user_id):
         """Set the user_id of this Authorization.
 
-        ID of user that created and owns the token.
+        ID of the user that created and owns the token.
 
         :param user_id: The user_id of this Authorization.
         :type: str
@@ -245,7 +245,7 @@ class Authorization(AuthorizationUpdateRequest):
     def user(self):
         """Get the user of this Authorization.
 
-        Name of user that created and owns the token.
+        Name of the user that created and owns the token.
 
         :return: The user of this Authorization.
         :rtype: str
@@ -256,7 +256,7 @@ class Authorization(AuthorizationUpdateRequest):
     def user(self, user):
         """Set the user of this Authorization.
 
-        Name of user that created and owns the token.
+        Name of the user that created and owns the token.
 
         :param user: The user of this Authorization.
         :type: str
@@ -267,7 +267,7 @@ class Authorization(AuthorizationUpdateRequest):
     def org(self):
         """Get the org of this Authorization.
 
-        Name of the org token is scoped to.
+        Name of the organization that the token is scoped to.
 
         :return: The org of this Authorization.
         :rtype: str
@@ -278,7 +278,7 @@ class Authorization(AuthorizationUpdateRequest):
     def org(self, org):
         """Set the org of this Authorization.
 
-        Name of the org token is scoped to.
+        Name of the organization that the token is scoped to.
 
         :param org: The org of this Authorization.
         :type: str

--- a/influxdb_client/domain/authorization_update_request.py
+++ b/influxdb_client/domain/authorization_update_request.py
@@ -56,7 +56,7 @@ class AuthorizationUpdateRequest(object):
     def status(self):
         """Get the status of this AuthorizationUpdateRequest.
 
-        If inactive the token is inactive and requests using the token will be rejected.
+        Status of the token. If `inactive`, requests using the token will be rejected.
 
         :return: The status of this AuthorizationUpdateRequest.
         :rtype: str
@@ -67,7 +67,7 @@ class AuthorizationUpdateRequest(object):
     def status(self, status):
         """Set the status of this AuthorizationUpdateRequest.
 
-        If inactive the token is inactive and requests using the token will be rejected.
+        Status of the token. If `inactive`, requests using the token will be rejected.
 
         :param status: The status of this AuthorizationUpdateRequest.
         :type: str

--- a/influxdb_client/domain/axis.py
+++ b/influxdb_client/domain/axis.py
@@ -76,7 +76,7 @@ class Axis(object):
     def bounds(self):
         """Get the bounds of this Axis.
 
-        The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits
+        The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.
 
         :return: The bounds of this Axis.
         :rtype: list[str]
@@ -87,7 +87,7 @@ class Axis(object):
     def bounds(self, bounds):
         """Set the bounds of this Axis.
 
-        The extents of an axis in the form [lower, upper]. Clients determine whether bounds are to be inclusive or exclusive of their limits
+        The extents of the axis in the form [lower, upper]. Clients determine whether bounds are inclusive or exclusive of their limits.
 
         :param bounds: The bounds of this Axis.
         :type: list[str]
@@ -98,7 +98,7 @@ class Axis(object):
     def label(self):
         """Get the label of this Axis.
 
-        Label is a description of this Axis
+        Description of the axis.
 
         :return: The label of this Axis.
         :rtype: str
@@ -109,7 +109,7 @@ class Axis(object):
     def label(self, label):
         """Set the label of this Axis.
 
-        Label is a description of this Axis
+        Description of the axis.
 
         :param label: The label of this Axis.
         :type: str
@@ -120,7 +120,7 @@ class Axis(object):
     def prefix(self):
         """Get the prefix of this Axis.
 
-        Prefix represents a label prefix for formatting axis values.
+        Label prefix for formatting axis values.
 
         :return: The prefix of this Axis.
         :rtype: str
@@ -131,7 +131,7 @@ class Axis(object):
     def prefix(self, prefix):
         """Set the prefix of this Axis.
 
-        Prefix represents a label prefix for formatting axis values.
+        Label prefix for formatting axis values.
 
         :param prefix: The prefix of this Axis.
         :type: str
@@ -142,7 +142,7 @@ class Axis(object):
     def suffix(self):
         """Get the suffix of this Axis.
 
-        Suffix represents a label suffix for formatting axis values.
+        Label suffix for formatting axis values.
 
         :return: The suffix of this Axis.
         :rtype: str
@@ -153,7 +153,7 @@ class Axis(object):
     def suffix(self, suffix):
         """Set the suffix of this Axis.
 
-        Suffix represents a label suffix for formatting axis values.
+        Label suffix for formatting axis values.
 
         :param suffix: The suffix of this Axis.
         :type: str
@@ -164,7 +164,7 @@ class Axis(object):
     def base(self):
         """Get the base of this Axis.
 
-        Base represents the radix for formatting axis values.
+        Radix for formatting axis values.
 
         :return: The base of this Axis.
         :rtype: str
@@ -175,7 +175,7 @@ class Axis(object):
     def base(self, base):
         """Set the base of this Axis.
 
-        Base represents the radix for formatting axis values.
+        Radix for formatting axis values.
 
         :param base: The base of this Axis.
         :type: str

--- a/influxdb_client/domain/dbrp.py
+++ b/influxdb_client/domain/dbrp.py
@@ -75,7 +75,7 @@ class DBRP(object):
     def id(self):
         """Get the id of this DBRP.
 
-        the mapping identifier
+        ID of the DBRP mapping.
 
         :return: The id of this DBRP.
         :rtype: str
@@ -86,7 +86,7 @@ class DBRP(object):
     def id(self, id):
         """Set the id of this DBRP.
 
-        the mapping identifier
+        ID of the DBRP mapping.
 
         :param id: The id of this DBRP.
         :type: str
@@ -99,7 +99,7 @@ class DBRP(object):
     def org_id(self):
         """Get the org_id of this DBRP.
 
-        the organization ID that owns this mapping.
+        ID of the organization that owns this mapping.
 
         :return: The org_id of this DBRP.
         :rtype: str
@@ -110,7 +110,7 @@ class DBRP(object):
     def org_id(self, org_id):
         """Set the org_id of this DBRP.
 
-        the organization ID that owns this mapping.
+        ID of the organization that owns this mapping.
 
         :param org_id: The org_id of this DBRP.
         :type: str
@@ -123,7 +123,7 @@ class DBRP(object):
     def bucket_id(self):
         """Get the bucket_id of this DBRP.
 
-        the bucket ID used as target for the translation.
+        ID of the bucket used as the target for the translation.
 
         :return: The bucket_id of this DBRP.
         :rtype: str
@@ -134,7 +134,7 @@ class DBRP(object):
     def bucket_id(self, bucket_id):
         """Set the bucket_id of this DBRP.
 
-        the bucket ID used as target for the translation.
+        ID of the bucket used as the target for the translation.
 
         :param bucket_id: The bucket_id of this DBRP.
         :type: str
@@ -195,7 +195,7 @@ class DBRP(object):
     def default(self):
         """Get the default of this DBRP.
 
-        Specify if this mapping represents the default retention policy for the database specificed.
+        Mapping represents the default retention policy for the database specified.
 
         :return: The default of this DBRP.
         :rtype: bool
@@ -206,7 +206,7 @@ class DBRP(object):
     def default(self, default):
         """Set the default of this DBRP.
 
-        Specify if this mapping represents the default retention policy for the database specificed.
+        Mapping represents the default retention policy for the database specified.
 
         :param default: The default of this DBRP.
         :type: bool

--- a/influxdb_client/domain/dbrp_create.py
+++ b/influxdb_client/domain/dbrp_create.py
@@ -73,7 +73,7 @@ class DBRPCreate(object):
     def org_id(self):
         """Get the org_id of this DBRPCreate.
 
-        the organization ID that owns this mapping.
+        ID of the organization that owns this mapping.
 
         :return: The org_id of this DBRPCreate.
         :rtype: str
@@ -84,7 +84,7 @@ class DBRPCreate(object):
     def org_id(self, org_id):
         """Set the org_id of this DBRPCreate.
 
-        the organization ID that owns this mapping.
+        ID of the organization that owns this mapping.
 
         :param org_id: The org_id of this DBRPCreate.
         :type: str
@@ -95,7 +95,7 @@ class DBRPCreate(object):
     def org(self):
         """Get the org of this DBRPCreate.
 
-        the organization that owns this mapping.
+        Name of the organization that owns this mapping.
 
         :return: The org of this DBRPCreate.
         :rtype: str
@@ -106,7 +106,7 @@ class DBRPCreate(object):
     def org(self, org):
         """Set the org of this DBRPCreate.
 
-        the organization that owns this mapping.
+        Name of the organization that owns this mapping.
 
         :param org: The org of this DBRPCreate.
         :type: str
@@ -117,7 +117,7 @@ class DBRPCreate(object):
     def bucket_id(self):
         """Get the bucket_id of this DBRPCreate.
 
-        the bucket ID used as target for the translation.
+        ID of the bucket used as the target for the translation.
 
         :return: The bucket_id of this DBRPCreate.
         :rtype: str
@@ -128,7 +128,7 @@ class DBRPCreate(object):
     def bucket_id(self, bucket_id):
         """Set the bucket_id of this DBRPCreate.
 
-        the bucket ID used as target for the translation.
+        ID of the bucket used as the target for the translation.
 
         :param bucket_id: The bucket_id of this DBRPCreate.
         :type: str
@@ -189,7 +189,7 @@ class DBRPCreate(object):
     def default(self):
         """Get the default of this DBRPCreate.
 
-        Specify if this mapping represents the default retention policy for the database specificed.
+        Mapping represents the default retention policy for the database specified.
 
         :return: The default of this DBRPCreate.
         :rtype: bool
@@ -200,7 +200,7 @@ class DBRPCreate(object):
     def default(self, default):
         """Set the default of this DBRPCreate.
 
-        Specify if this mapping represents the default retention policy for the database specificed.
+        Mapping represents the default retention policy for the database specified.
 
         :param default: The default of this DBRPCreate.
         :type: bool

--- a/influxdb_client/domain/error.py
+++ b/influxdb_client/domain/error.py
@@ -54,7 +54,8 @@ class Error(object):
         self.discriminator = None
 
         self.code = code
-        self.message = message
+        if message is not None:
+            self.message = message
         if op is not None:
             self.op = op
         if err is not None:
@@ -88,7 +89,7 @@ class Error(object):
     def message(self):
         """Get the message of this Error.
 
-        message is a human-readable message.
+        Human-readable message.
 
         :return: The message of this Error.
         :rtype: str
@@ -99,20 +100,18 @@ class Error(object):
     def message(self, message):
         """Set the message of this Error.
 
-        message is a human-readable message.
+        Human-readable message.
 
         :param message: The message of this Error.
         :type: str
         """  # noqa: E501
-        if message is None:
-            raise ValueError("Invalid value for `message`, must not be `None`")  # noqa: E501
         self._message = message
 
     @property
     def op(self):
         """Get the op of this Error.
 
-        op describes the logical code operation during error. Useful for debugging.
+        Describes the logical code operation when the error occurred. Useful for debugging.
 
         :return: The op of this Error.
         :rtype: str
@@ -123,7 +122,7 @@ class Error(object):
     def op(self, op):
         """Set the op of this Error.
 
-        op describes the logical code operation during error. Useful for debugging.
+        Describes the logical code operation when the error occurred. Useful for debugging.
 
         :param op: The op of this Error.
         :type: str
@@ -134,7 +133,7 @@ class Error(object):
     def err(self):
         """Get the err of this Error.
 
-        err is a stack of errors that occurred during processing of the request. Useful for debugging.
+        Stack of errors that occurred during processing of the request. Useful for debugging.
 
         :return: The err of this Error.
         :rtype: str
@@ -145,7 +144,7 @@ class Error(object):
     def err(self, err):
         """Set the err of this Error.
 
-        err is a stack of errors that occurred during processing of the request. Useful for debugging.
+        Stack of errors that occurred during processing of the request. Useful for debugging.
 
         :param err: The err of this Error.
         :type: str

--- a/influxdb_client/domain/line_protocol_error.py
+++ b/influxdb_client/domain/line_protocol_error.py
@@ -57,9 +57,12 @@ class LineProtocolError(object):
         self.discriminator = None
 
         self.code = code
-        self.message = message
-        self.op = op
-        self.err = err
+        if message is not None:
+            self.message = message
+        if op is not None:
+            self.op = op
+        if err is not None:
+            self.err = err
         if line is not None:
             self.line = line
 
@@ -91,7 +94,7 @@ class LineProtocolError(object):
     def message(self):
         """Get the message of this LineProtocolError.
 
-        Message is a human-readable message.
+        Human-readable message.
 
         :return: The message of this LineProtocolError.
         :rtype: str
@@ -102,20 +105,18 @@ class LineProtocolError(object):
     def message(self, message):
         """Set the message of this LineProtocolError.
 
-        Message is a human-readable message.
+        Human-readable message.
 
         :param message: The message of this LineProtocolError.
         :type: str
         """  # noqa: E501
-        if message is None:
-            raise ValueError("Invalid value for `message`, must not be `None`")  # noqa: E501
         self._message = message
 
     @property
     def op(self):
         """Get the op of this LineProtocolError.
 
-        Op describes the logical code operation during error. Useful for debugging.
+        Describes the logical code operation when the error occurred. Useful for debugging.
 
         :return: The op of this LineProtocolError.
         :rtype: str
@@ -126,20 +127,18 @@ class LineProtocolError(object):
     def op(self, op):
         """Set the op of this LineProtocolError.
 
-        Op describes the logical code operation during error. Useful for debugging.
+        Describes the logical code operation when the error occurred. Useful for debugging.
 
         :param op: The op of this LineProtocolError.
         :type: str
         """  # noqa: E501
-        if op is None:
-            raise ValueError("Invalid value for `op`, must not be `None`")  # noqa: E501
         self._op = op
 
     @property
     def err(self):
         """Get the err of this LineProtocolError.
 
-        Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+        Stack of errors that occurred during processing of the request. Useful for debugging.
 
         :return: The err of this LineProtocolError.
         :rtype: str
@@ -150,20 +149,18 @@ class LineProtocolError(object):
     def err(self, err):
         """Set the err of this LineProtocolError.
 
-        Err is a stack of errors that occurred during processing of the request. Useful for debugging.
+        Stack of errors that occurred during processing of the request. Useful for debugging.
 
         :param err: The err of this LineProtocolError.
         :type: str
         """  # noqa: E501
-        if err is None:
-            raise ValueError("Invalid value for `err`, must not be `None`")  # noqa: E501
         self._err = err
 
     @property
     def line(self):
         """Get the line of this LineProtocolError.
 
-        First line within sent body containing malformed data
+        First line in the request body that contains malformed data.
 
         :return: The line of this LineProtocolError.
         :rtype: int
@@ -174,7 +171,7 @@ class LineProtocolError(object):
     def line(self, line):
         """Set the line of this LineProtocolError.
 
-        First line within sent body containing malformed data
+        First line in the request body that contains malformed data.
 
         :param line: The line of this LineProtocolError.
         :type: int

--- a/influxdb_client/domain/line_protocol_length_error.py
+++ b/influxdb_client/domain/line_protocol_length_error.py
@@ -78,7 +78,7 @@ class LineProtocolLengthError(object):
     def message(self):
         """Get the message of this LineProtocolLengthError.
 
-        Message is a human-readable message.
+        Human-readable message.
 
         :return: The message of this LineProtocolLengthError.
         :rtype: str
@@ -89,7 +89,7 @@ class LineProtocolLengthError(object):
     def message(self, message):
         """Set the message of this LineProtocolLengthError.
 
-        Message is a human-readable message.
+        Human-readable message.
 
         :param message: The message of this LineProtocolLengthError.
         :type: str

--- a/influxdb_client/domain/task.py
+++ b/influxdb_client/domain/task.py
@@ -162,7 +162,7 @@ class Task(object):
     def type(self):
         """Get the type of this Task.
 
-        The type of task, this can be used for filtering tasks on list actions.
+        Type of the task, useful for filtering a task list.
 
         :return: The type of this Task.
         :rtype: str
@@ -173,7 +173,7 @@ class Task(object):
     def type(self, type):
         """Set the type of this Task.
 
-        The type of task, this can be used for filtering tasks on list actions.
+        Type of the task, useful for filtering a task list.
 
         :param type: The type of this Task.
         :type: str
@@ -184,7 +184,7 @@ class Task(object):
     def org_id(self):
         """Get the org_id of this Task.
 
-        The ID of the organization that owns this Task.
+        ID of the organization that owns the task.
 
         :return: The org_id of this Task.
         :rtype: str
@@ -195,7 +195,7 @@ class Task(object):
     def org_id(self, org_id):
         """Set the org_id of this Task.
 
-        The ID of the organization that owns this Task.
+        ID of the organization that owns the task.
 
         :param org_id: The org_id of this Task.
         :type: str
@@ -208,7 +208,7 @@ class Task(object):
     def org(self):
         """Get the org of this Task.
 
-        The name of the organization that owns this Task.
+        Name of the organization that owns the task.
 
         :return: The org of this Task.
         :rtype: str
@@ -219,7 +219,7 @@ class Task(object):
     def org(self, org):
         """Set the org of this Task.
 
-        The name of the organization that owns this Task.
+        Name of the organization that owns the task.
 
         :param org: The org of this Task.
         :type: str
@@ -230,7 +230,7 @@ class Task(object):
     def name(self):
         """Get the name of this Task.
 
-        The name of the task.
+        Name of the task.
 
         :return: The name of this Task.
         :rtype: str
@@ -241,7 +241,7 @@ class Task(object):
     def name(self, name):
         """Set the name of this Task.
 
-        The name of the task.
+        Name of the task.
 
         :param name: The name of this Task.
         :type: str
@@ -254,7 +254,7 @@ class Task(object):
     def owner_id(self):
         """Get the owner_id of this Task.
 
-        The ID of the user who owns this Task.
+        ID of the user who owns this Task.
 
         :return: The owner_id of this Task.
         :rtype: str
@@ -265,7 +265,7 @@ class Task(object):
     def owner_id(self, owner_id):
         """Set the owner_id of this Task.
 
-        The ID of the user who owns this Task.
+        ID of the user who owns this Task.
 
         :param owner_id: The owner_id of this Task.
         :type: str
@@ -276,7 +276,7 @@ class Task(object):
     def description(self):
         """Get the description of this Task.
 
-        An optional description of the task.
+        Description of the task.
 
         :return: The description of this Task.
         :rtype: str
@@ -287,7 +287,7 @@ class Task(object):
     def description(self, description):
         """Set the description of this Task.
 
-        An optional description of the task.
+        Description of the task.
 
         :param description: The description of this Task.
         :type: str
@@ -334,7 +334,7 @@ class Task(object):
     def authorization_id(self):
         """Get the authorization_id of this Task.
 
-        The ID of the authorization used when this task communicates with the query engine.
+        ID of the authorization used when the task communicates with the query engine.
 
         :return: The authorization_id of this Task.
         :rtype: str
@@ -345,7 +345,7 @@ class Task(object):
     def authorization_id(self, authorization_id):
         """Set the authorization_id of this Task.
 
-        The ID of the authorization used when this task communicates with the query engine.
+        ID of the authorization used when the task communicates with the query engine.
 
         :param authorization_id: The authorization_id of this Task.
         :type: str
@@ -356,7 +356,7 @@ class Task(object):
     def flux(self):
         """Get the flux of this Task.
 
-        The Flux script to run for this task.
+        Flux script to run for this task.
 
         :return: The flux of this Task.
         :rtype: str
@@ -367,7 +367,7 @@ class Task(object):
     def flux(self, flux):
         """Set the flux of this Task.
 
-        The Flux script to run for this task.
+        Flux script to run for this task.
 
         :param flux: The flux of this Task.
         :type: str
@@ -380,7 +380,7 @@ class Task(object):
     def every(self):
         """Get the every of this Task.
 
-        A simple task repetition schedule; parsed from Flux.
+        Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time. Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
 
         :return: The every of this Task.
         :rtype: str
@@ -391,7 +391,7 @@ class Task(object):
     def every(self, every):
         """Set the every of this Task.
 
-        A simple task repetition schedule; parsed from Flux.
+        Interval at which the task runs. `every` also determines when the task first runs, depending on the specified time. Value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals)).
 
         :param every: The every of this Task.
         :type: str
@@ -402,7 +402,7 @@ class Task(object):
     def cron(self):
         """Get the cron of this Task.
 
-        A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+        [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time. Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
 
         :return: The cron of this Task.
         :rtype: str
@@ -413,7 +413,7 @@ class Task(object):
     def cron(self, cron):
         """Set the cron of this Task.
 
-        A task repetition schedule in the form '* * * * * *'; parsed from Flux.
+        [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. Cron scheduling is based on system time. Value is a [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview).
 
         :param cron: The cron of this Task.
         :type: str
@@ -424,7 +424,7 @@ class Task(object):
     def offset(self):
         """Get the offset of this Task.
 
-        Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.
+        [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset. The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
 
         :return: The offset of this Task.
         :rtype: str
@@ -435,7 +435,7 @@ class Task(object):
     def offset(self, offset):
         """Set the offset of this Task.
 
-        Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.
+        [Duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset. The value is a [duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals).
 
         :param offset: The offset of this Task.
         :type: str
@@ -446,7 +446,7 @@ class Task(object):
     def latest_completed(self):
         """Get the latest_completed of this Task.
 
-        Timestamp of latest scheduled, completed run, RFC3339.
+        Timestamp of the latest scheduled and completed run. Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
 
         :return: The latest_completed of this Task.
         :rtype: datetime
@@ -457,7 +457,7 @@ class Task(object):
     def latest_completed(self, latest_completed):
         """Set the latest_completed of this Task.
 
-        Timestamp of latest scheduled, completed run, RFC3339.
+        Timestamp of the latest scheduled and completed run. Value is a timestamp in [RFC3339 date/time format](https://docs.influxdata.com/flux/v0.x/data-types/basic/time/#time-syntax).
 
         :param latest_completed: The latest_completed of this Task.
         :type: datetime

--- a/influxdb_client/service/buckets_service.py
+++ b/influxdb_client/service/buckets_service.py
@@ -484,7 +484,7 @@ class BucketsService(object):
         :param str zap_trace_span: OpenTracing span context
         :param int offset:
         :param int limit:
-        :param str after: The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        :param str after: Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
         :param str org: The name of the organization.
         :param str org_id: The organization ID.
         :param str name: Only returns buckets with a specific name.
@@ -512,7 +512,7 @@ class BucketsService(object):
         :param str zap_trace_span: OpenTracing span context
         :param int offset:
         :param int limit:
-        :param str after: The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        :param str after: Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
         :param str org: The name of the organization.
         :param str org_id: The organization ID.
         :param str name: Only returns buckets with a specific name.

--- a/influxdb_client/service/users_service.py
+++ b/influxdb_client/service/users_service.py
@@ -340,7 +340,7 @@ class UsersService(object):
         :param str zap_trace_span: OpenTracing span context
         :param int offset:
         :param int limit:
-        :param str after: The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        :param str after: Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
         :param str name:
         :param str id:
         :return: Users
@@ -366,7 +366,7 @@ class UsersService(object):
         :param str zap_trace_span: OpenTracing span context
         :param int offset:
         :param int limit:
-        :param str after: The last resource ID from which to seek from (but not including). This is to be used instead of `offset`.
+        :param str after: Resource ID to seek from. Results are not inclusive of this ID. Use `after` instead of `offset`.
         :param str name:
         :param str id:
         :return: Users


### PR DESCRIPTION
## Proposed Changes

1. Updated API to latest version.
2. Added InvocableScripts API to create, list, delete and invoke scripts by seamless way.3. 
3. `FluxCSVParser` is able to parse data without datatype annotations.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
