### PR TITLE
fix: use pandas.concat() instead of deprecated DataFrame.append()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This release introduces a support for new version of InfluxDB OSS API definition
 
 ### Bug Fixes
 1. [#408](https://github.com/influxdata/influxdb-client-python/pull/408): Improve error message when the client cannot find organization by name
+1. [#407](https://github.com/influxdata/influxdb-client-python/pull/407): Use `pandas.concat()` instead of deprecated `DataFrame.append()` [DataFrame]
 
 ## 1.25.0 [2022-01-20]
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -187,7 +187,7 @@ class FluxCsvParser(object):
             _temp_df = _temp_df.set_index(self._data_frame_index)
 
         # Append data
-        return self._data_frame.astype(_temp_df.dtypes).append(_temp_df)
+        return pd.concat([self._data_frame.astype(_temp_df.dtypes), _temp_df])
 
     def parse_record(self, table_index, table, csv):
         """Parse one record."""


### PR DESCRIPTION
Closes #406 

## Proposed Changes

Use `pandas.concat()` instead of deprecated `DataFrame.append()`:

![image](https://user-images.githubusercontent.com/455137/154213424-d49ee816-a631-44bc-bef1-bfb7343710c7.png)
https://pandas.pydata.org/docs/dev/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
