### PR TITLE
chore: improve error message when the client cannot find org by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ This release introduces a support for new version of InfluxDB OSS API definition
 ### API
 1. [#399](https://github.com/influxdata/influxdb-client-python/pull/399): Use the latest InfluxDB OSS API definitions to generated APIs
 
+### Bug Fixes
+1. [#408](https://github.com/influxdata/influxdb-client-python/pull/408): Improve error message when the client cannot find organization by name
+
 ## 1.25.0 [2022-01-20]
 
 ### Features

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class InfluxDBError(Exception):
     """Raised when a server error occurs."""
 
-    def __init__(self, response: HTTPResponse):
+    def __init__(self, response: HTTPResponse = None, message: str = None):
         """Initialize the InfluxDBError handler."""
         if response is not None:
             self.response = response
@@ -18,7 +18,7 @@ class InfluxDBError(Exception):
             self.retry_after = response.getheader('Retry-After')
         else:
             self.response = None
-            self.message = 'no response'
+            self.message = message or 'no response'
             self.retry_after = None
         super().__init__(self.message)
 

--- a/influxdb_client/client/util/helpers.py
+++ b/influxdb_client/client/util/helpers.py
@@ -32,7 +32,13 @@ def get_org_query_param(org, client, required_id=False):
         _org = _org.id
     if required_id and _org and not _is_id(_org):
         try:
-            return client.organizations_api().find_organizations(org=_org)[0].id
+            organizations = client.organizations_api().find_organizations(org=_org)
+            if len(organizations) < 1:
+                from influxdb_client.client.exceptions import InfluxDBError
+                message = f"The client cannot find organization with name: '{_org}' " \
+                          "to determine their ID. Are you using token with sufficient permission?"
+                raise InfluxDBError(response=None, message=message)
+            return organizations[0].id
         except ApiException:
             return None
 


### PR DESCRIPTION
Closes #403

## Proposed Changes

Add better error message when the used `token` doesn't have permission to read organizations.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
