### PR TITLE
feat: DeleteApi uses default value from `InfluxDBClient.org` if org parameter is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.27.0 [unreleased]
 
+### Features
+1. [#412](https://github.com/influxdata/influxdb-client-python/pull/412): `DeleteApi` uses default value from `InfluxDBClient.org` if an `org` parameter is not specified
+
 ### CI
- 1. [#411](https://github.com/influxdata/influxdb-client-python/pull/411): Use new Codecov uploader for reporting code coverage
+1. [#411](https://github.com/influxdata/influxdb-client-python/pull/411): Use new Codecov uploader for reporting code coverage
 
 ## 1.26.0 [2022-02-18]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ def setup(app):
 
 
 project = 'influxdb_client'
-copyright = '2019 InfluxData, Inc'
+copyright = '2022 InfluxData, Inc'
 author = 'Robert Hajek, Jakub Bednar'
 
 autoclass_content = 'both'

--- a/influxdb_client/client/bucket_api.py
+++ b/influxdb_client/client/bucket_api.py
@@ -29,8 +29,8 @@ class BucketsApi(object):
         :param bucket_name: bucket name
         :param retention_rules: retention rules array or single BucketRetentionRules
         :param str, Organization org: specifies the organization for create the bucket;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :return: Bucket
                  If the method is called asynchronously,
                  returns the request thread.

--- a/influxdb_client/client/delete_api.py
+++ b/influxdb_client/client/delete_api.py
@@ -1,9 +1,11 @@
 """Delete time series data from InfluxDB."""
 
 from datetime import datetime
+from typing import Union
 
-from influxdb_client import DeleteService, DeletePredicateRequest
+from influxdb_client import DeleteService, DeletePredicateRequest, Organization
 from influxdb_client.client.util.date_utils import get_date_helper
+from influxdb_client.client.util.helpers import get_org_query_param
 
 
 class DeleteApi(object):
@@ -14,15 +16,18 @@ class DeleteApi(object):
         self._influxdb_client = influxdb_client
         self._service = DeleteService(influxdb_client.api_client)
 
-    def delete(self, start: datetime, stop: object, predicate: object, bucket: str, org: str) -> None:
+    def delete(self, start: Union[str, datetime], stop: Union[str, datetime], predicate: str, bucket: str,
+               org: Union[str, Organization, None] = None) -> None:
         """
         Delete Time series data from InfluxDB.
 
-        :param start: start time
-        :param stop: stop time
-        :param predicate: predicate
-        :param bucket: bucket id or name from which data will be deleted
-        :param org: organization id or name
+        :param str, datetime.datetime start: start time
+        :param str, datetime.datetime stop: stop time
+        :param str predicate: predicate
+        :param str bucket: bucket id or name from which data will be deleted
+        :param str, Organization org: specifies the organization to delete data from.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :return:
         """
         date_helper = get_date_helper()
@@ -31,5 +36,7 @@ class DeleteApi(object):
         if isinstance(stop, datetime):
             stop = date_helper.to_utc(stop)
 
+        org_param = get_org_query_param(org=org, client=self._influxdb_client, required_id=False)
+
         predicate_request = DeletePredicateRequest(start=start, stop=stop, predicate=predicate)
-        return self._service.post_delete(delete_predicate_request=predicate_request, bucket=bucket, org=org)
+        return self._service.post_delete(delete_predicate_request=predicate_request, bucket=bucket, org=org_param)

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -37,9 +37,9 @@ class InfluxDBClient(object):
         :param timeout: HTTP client timeout setting for a request specified in milliseconds.
                         If one number provided, it will be total request timeout.
                         It can also be a pair (tuple) of (connection, read) timeouts.
-        :param enable_gzip: Enable Gzip compression for http requests. Currently only the "Write" and "Query" endpoints
+        :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
-        :param org: organization name (used as a default in query and write API)
+        :param org: organization name (used as a default in Query, Write and Delete API)
         :key bool verify_ssl: Set this to false to skip verifying SSL certificate when calling API from https server.
         :key str ssl_ca_cert: Set this to customize the certificate file to verify the peer.
         :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -55,8 +55,8 @@ class QueryApi(object):
 
         :param query: a Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param dialect: csv dialect format
         :param params: bind parameters
         :return: The returned object is an iterator.  Each iteration returns a row of the CSV file
@@ -74,8 +74,8 @@ class QueryApi(object):
 
         :param query: a Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param dialect: csv dialect format
         :param params: bind parameters
         :return: str
@@ -92,8 +92,8 @@ class QueryApi(object):
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param params: bind parameters
         :return:
         """
@@ -115,8 +115,8 @@ class QueryApi(object):
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param params: bind parameters
         :return:
         """
@@ -138,8 +138,8 @@ class QueryApi(object):
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
         :return:
@@ -165,8 +165,8 @@ class QueryApi(object):
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      Take the ``ID``, ``Name`` or ``Organization``.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
         :return:

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -292,8 +292,8 @@ class WriteApi:
 
         :param str bucket: specifies the destination bucket for writes (required)
         :param str, Organization org: specifies the destination organization for writes;
-                                      take the ID, Name or Organization;
-                                      if it's not specified then is used default from client.org.
+                                      take the ID, Name or Organization.
+                                      If not specified the default value from ``InfluxDBClient.org`` is used.
         :param WritePrecision write_precision: specifies the precision for the unix timestamps within
                                                the body line-protocol. The precision specified on a Point has precedes
                                                and is use for write.

--- a/tests/test_DeleteApi.py
+++ b/tests/test_DeleteApi.py
@@ -60,7 +60,20 @@ class DeleteApiTest(BaseTest):
 
         start = "1970-01-01T00:00:00.000000001Z"
         stop = "1970-01-01T00:00:00.000000012Z"
-        self._delete_and_verify(start, stop)
+        self._delete_and_verify(start, stop, self.organization.name)
+
+    def test_delete_org_parameters_types(self):
+
+        orgs = [
+            self.organization,
+            self.organization.id,
+            self.organization.name,
+            None
+        ]
+
+        for org in orgs:
+            self._write_data()
+            self._delete_and_verify("1970-01-01T00:00:00.000000001Z", "1970-01-01T00:00:00.000000012Z", org)
 
     def test_start_stop_types(self):
         starts_stops = [
@@ -70,10 +83,10 @@ class DeleteApiTest(BaseTest):
         ]
         for start_stop in starts_stops:
             self._write_data()
-            self._delete_and_verify(start_stop[0], start_stop[1])
+            self._delete_and_verify(start_stop[0], start_stop[1], self.organization.name)
 
-    def _delete_and_verify(self, start, stop):
-        self.delete_api.delete(start, stop, "", bucket=self.bucket.name, org=self.organization.name)
+    def _delete_and_verify(self, start, stop, org):
+        self.delete_api.delete(start, stop, "", bucket=self.bucket.name, org=org)
         flux_tables = self.client.query_api().query(
             f'from(bucket:"{self.bucket.name}") |> range(start: 1970-01-01T00:00:00.000000001Z)',
             org=self.organization.id)

--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -327,7 +327,10 @@ class DataSerializerTest(unittest.TestCase):
         from influxdb_client.extras import pd, np
         now = pd.Timestamp('2020-04-05 00:00+00:00')
 
-        for np_float_type in [np.float, np.float16, np.float32, np.float64, np.float128]:
+        float_types = [np.float, np.float16, np.float32, np.float64]
+        if hasattr(np, 'float128'):
+            float_types.append(np.float128)
+        for np_float_type in float_types:
             data_frame = pd.DataFrame([15.5], index=[now], columns=['level']).astype(np_float_type)
             points = data_frame_to_list_of_points(data_frame=data_frame,
                                                   data_frame_measurement_name='h2o',


### PR DESCRIPTION
Related to https://influxcommunity.slack.com/archives/CHQ5VG6F8/p1645606126853649

## Proposed Changes

`DeleteApi` uses default value from `InfluxDBClient.org` if org parameter is not specified.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
