### PR TITLE
fix: fix DeprecationWarning in write API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 1. [#412](https://github.com/influxdata/influxdb-client-python/pull/412): `DeleteApi` uses default value from `InfluxDBClient.org` if an `org` parameter is not specified
 1. [#405](https://github.com/influxdata/influxdb-client-python/pull/405): Add `InfluxLoggingHandler`. A handler to use the client in native python logging.
 1. [#404](https://github.com/influxdata/influxdb-client-python/pull/404): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
-1. [#419](https://github.com/influxdata/influxdb-client-python/pull/419): Bump urllib3 to 1.26.0 and change `method_whitelist` to `allowed_methods` to clear deprecation warning
+
+### Bug Fixes
+1. [#419](https://github.com/influxdata/influxdb-client-python/pull/419): Use `allowed_methods` to clear deprecation warning [urllib3]
+
+### Dependencies
+1. [#419](https://github.com/influxdata/influxdb-client-python/pull/419): Update dependencies:
+   - `urllib3` to 1.26.0 
 
 ### CI
 1. [#411](https://github.com/influxdata/influxdb-client-python/pull/411): Use new Codecov uploader for reporting code coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#412](https://github.com/influxdata/influxdb-client-python/pull/412): `DeleteApi` uses default value from `InfluxDBClient.org` if an `org` parameter is not specified
 1. [#405](https://github.com/influxdata/influxdb-client-python/pull/405): Add `InfluxLoggingHandler`. A handler to use the client in native python logging.
 1. [#404](https://github.com/influxdata/influxdb-client-python/pull/404): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+1. [#419](https://github.com/influxdata/influxdb-client-python/pull/419): Bump urllib3 to 1.26.0 and change `method_whitelist` to `allowed_methods` to clear deprecation warning
 
 ### CI
 1. [#411](https://github.com/influxdata/influxdb-client-python/pull/411): Use new Codecov uploader for reporting code coverage

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -95,7 +95,7 @@ class WriteOptions(object):
             max_retry_time=self.max_retry_time / 1_000,
             exponential_base=self.exponential_base,
             retry_callback=kwargs.get("retry_callback", None),
-            method_whitelist=["POST"])
+            allowed_methods=["POST"])
 
     def __getstate__(self):
         """Return a dict of attributes that you want to pickle."""

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
     'six >= 1.10',
     'python_dateutil >= 2.5.3',
     'setuptools >= 21.0.0',
-    'urllib3 >= 1.15.1',
+    'urllib3 >= 1.26.0',
     'pytz>=2019.1'
 ]
 

--- a/tests/test_WriteOptions.py
+++ b/tests/test_WriteOptions.py
@@ -12,7 +12,7 @@ class TestWriteOptions(unittest.TestCase):
         self.assertEqual(retry.max_retry_time, 180)
         self.assertEqual(retry.max_retry_delay, 125)
         self.assertEqual(retry.exponential_base, 2)
-        self.assertEqual(retry.method_whitelist, ["POST"])
+        self.assertEqual(retry.allowed_methods, ["POST"])
 
     def test_custom(self):
         retry = WriteOptions(max_retries=5, max_retry_delay=7500,
@@ -24,4 +24,4 @@ class TestWriteOptions(unittest.TestCase):
         self.assertEqual(retry.retry_interval, 0.5)
         self.assertEqual(retry.max_retry_delay, 7.5)
         self.assertEqual(retry.exponential_base, 2)
-        self.assertEqual(retry.method_whitelist, ["POST"])
+        self.assertEqual(retry.allowed_methods, ["POST"])

--- a/tests/test_WritesRetry.py
+++ b/tests/test_WritesRetry.py
@@ -184,27 +184,27 @@ class TestWritesRetry(unittest.TestCase):
         self.assertLessEqual(retry_after, 7)
 
     def test_is_retry(self):
-        retry = WritesRetry(method_whitelist=["POST"])
+        retry = WritesRetry(allowed_methods=["POST"])
 
         self.assertTrue(retry.is_retry("POST", 429, True))
 
     def test_is_retry_428(self):
-        retry = WritesRetry(method_whitelist=["POST"])
+        retry = WritesRetry(allowed_methods=["POST"])
 
         self.assertFalse(retry.is_retry("POST", 428, True))
 
     def test_is_retry_430(self):
-        retry = WritesRetry(method_whitelist=["POST"])
+        retry = WritesRetry(allowed_methods=["POST"])
 
         self.assertTrue(retry.is_retry("POST", 430, True))
 
     def test_is_retry_retry_after_header_is_not_required(self):
-        retry = WritesRetry(method_whitelist=["POST"])
+        retry = WritesRetry(allowed_methods=["POST"])
 
         self.assertTrue(retry.is_retry("POST", 429, False))
 
     def test_is_retry_respect_method(self):
-        retry = WritesRetry(method_whitelist=["POST"])
+        retry = WritesRetry(allowed_methods=["POST"])
 
         self.assertFalse(retry.is_retry("GET", 429, False))
 


### PR DESCRIPTION
## Proposed Changes

Was getting this warning using the client with Python 3.9:
```
/lib/python3.9/site-packages/influxdb_client/client/write/retry.py:47: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    super().__init__(**kw)
```
This commit should fix things by moving to the new parameter name for `urllib3`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
