### PR TITLE
chore: Improve error message if there is no organization with required name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.28.0 [unreleased]
 
+### Bug Fixes
+1. [#425](https://github.com/influxdata/influxdb-client-python/pull/425): Improve error message if there is no `organization` with required `name`
+
 ## 1.27.0 [2022-03-18]
 
 ### Features

--- a/influxdb_client/client/util/helpers.py
+++ b/influxdb_client/client/util/helpers.py
@@ -39,7 +39,12 @@ def get_org_query_param(org, client, required_id=False):
                           "to determine their ID. Are you using token with sufficient permission?"
                 raise InfluxDBError(response=None, message=message)
             return organizations[0].id
-        except ApiException:
-            return None
+        except ApiException as e:
+            if e.status == 404:
+                from influxdb_client.client.exceptions import InfluxDBError
+                message = f"The client cannot find organization with name: '{_org}' " \
+                          "to determine their ID."
+                raise InfluxDBError(response=None, message=message)
+            raise e
 
     return _org

--- a/tests/test_Helpers.py
+++ b/tests/test_Helpers.py
@@ -31,8 +31,9 @@ class HelpersTest(BaseTest):
         self.assertEqual(self.my_organization.id, org)
 
     def test_required_id_not_exist(self):
-        org = get_org_query_param("not_exist_name", self.client, required_id=True)
-        self.assertIsNone(org)
+        with pytest.raises(InfluxDBError) as e:
+            get_org_query_param("not_exist_name", self.client, required_id=True)
+        assert "The client cannot find organization with name: 'not_exist_name' to determine their ID." in f"{e.value} "
 
     def test_both_none(self):
         self.client.close()


### PR DESCRIPTION
Closes #424

## Proposed Changes

Improved error message for lookup to organization.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
