### PR TITLE
chore: check present for async context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.28.0 [unreleased]
 
+### Features
+1. [#413](https://github.com/influxdata/influxdb-client-python/pull/413): Add support for `async/await` with asyncio via `InfluxDBClientAsync`, for more info see: **How to use Asyncio**
+
 ### Bug Fixes
 1. [#425](https://github.com/influxdata/influxdb-client-python/pull/425): Improve error message if there is no `organization` with required `name`
 
@@ -9,7 +12,6 @@
 1. [#412](https://github.com/influxdata/influxdb-client-python/pull/412): `DeleteApi` uses default value from `InfluxDBClient.org` if an `org` parameter is not specified
 1. [#405](https://github.com/influxdata/influxdb-client-python/pull/405): Add `InfluxLoggingHandler`. A handler to use the client in native python logging.
 1. [#404](https://github.com/influxdata/influxdb-client-python/pull/404): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
-1. [#413](https://github.com/influxdata/influxdb-client-python/pull/413): Add support for `async/await` with asyncio via `InfluxDBClientAsync`, for more info see: **How to use Asyncio**
 
 ### Bug Fixes
 1. [#419](https://github.com/influxdata/influxdb-client-python/pull/419): Use `allowed_methods` to clear deprecation warning [urllib3]

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ influxdb-client-python
    :target: https://pypi.python.org/pypi/influxdb-client
    :alt: Supported Python versions
 
-.. image:: https://readthedocs.org/projects/influxdb-client/badge/?version=latest
-   :target: https://influxdb-client.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/influxdb-client/badge/?version=stable
+   :target: https://influxdb-client.readthedocs.io/en/stable/
    :alt: Documentation status
 
 .. image:: https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -1,4 +1,5 @@
 """InfluxDBClientAsync is client for API defined in https://github.com/influxdata/openapi/blob/master/contracts/oss.yml."""  # noqa: E501
+import asyncio
 import logging
 
 from influxdb_client import PingService
@@ -46,6 +47,15 @@ class InfluxDBClientAsync(_BaseClient):
         :key list[str] profilers: list of enabled Flux profilers
         """
         super().__init__(url=url, token=token, org=org, debug=debug, timeout=timeout, enable_gzip=enable_gzip, **kwargs)
+
+        # check present asynchronous context
+        try:
+            _ = asyncio.events.get_running_loop()
+        except RuntimeError:
+            from influxdb_client.client.exceptions import InfluxDBError
+            message = "The async client should be initialised inside async coroutine " \
+                      "otherwise there can be unexpected behaviour."
+            raise InfluxDBError(response=None, message=message)
 
         from .._async.api_client import ApiClientAsync
         self.api_client = ApiClientAsync(configuration=self.conf, header_name=self.auth_header_name,

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -1,6 +1,6 @@
 """InfluxDBClientAsync is client for API defined in https://github.com/influxdata/openapi/blob/master/contracts/oss.yml."""  # noqa: E501
-import asyncio
 import logging
+import sys
 
 from influxdb_client import PingService
 from influxdb_client.client._base import _BaseClient
@@ -48,9 +48,18 @@ class InfluxDBClientAsync(_BaseClient):
         """
         super().__init__(url=url, token=token, org=org, debug=debug, timeout=timeout, enable_gzip=enable_gzip, **kwargs)
 
+        # compatibility with Python 3.6
+        if sys.version_info[:2] >= (3, 7):
+            from asyncio import get_running_loop
+        else:
+            from asyncio import _get_running_loop as get_running_loop
+
         # check present asynchronous context
         try:
-            _ = asyncio.events.get_running_loop()
+            loop = get_running_loop()
+            # compatibility with Python 3.6
+            if loop is None:
+                raise RuntimeError('no running event loop')
         except RuntimeError:
             from influxdb_client.client.exceptions import InfluxDBError
             message = "The async client should be initialised inside async coroutine " \

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -3,7 +3,10 @@ import unittest
 import os
 from datetime import datetime
 
+import pytest
+
 from influxdb_client import Point, WritePrecision
+from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 from tests.base_test import generate_name
 
@@ -222,6 +225,12 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         self.assertEqual(5500, client_from_envs.api_client.configuration.timeout)
 
         await client_from_envs.close()
+
+    def test_initialize_out_side_async_context(self):
+        with pytest.raises(InfluxDBError) as e:
+            InfluxDBClientAsync(url="http://localhost:8086", token="my-token", org="my-org")
+        self.assertEqual("The async client should be initialised inside async coroutine "
+                         "otherwise there can be unexpected behaviour.", e.value.message)
 
 
     async def _prepare_data(self, measurement: str):


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/issues/205#issuecomment-1077819296

## Proposed Changes

Checking if the `async` client is used in async context.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
