### PR TITLE
fix(test): reflect changes in InfluxDB 2.2

### DIFF
--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -342,7 +342,7 @@ class SynchronousWriteTest(BaseTest):
         bucket = self.create_test_bucket()
 
         from distutils.version import LooseVersion
-        version = self.client.version()
+        version = self.client.version().strip('v')
         if 'nightly' not in version and LooseVersion(version) <= LooseVersion("2.0.8"):
             with self.assertRaises(ApiException) as cm:
                 self.write_client.write(bucket.name, record="")


### PR DESCRIPTION
## Proposed Changes

Fix tests to be compatible with InfluxDB 2.2.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
