### PR TITLE
fix: initialization of the client without auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.30.0 [unreleased]
 
+## 1.29.1 [unreleased]
+
+### Bug Fixes
+1. [#443](https://github.com/influxdata/influxdb-client-python/pull/443): Initialization of the client without auth credentials
+
 ## 1.29.0 [2022-05-20]
 
 ### Breaking Changes

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -72,15 +72,17 @@ class _BaseClient(object):
 
         self.conf.username = kwargs.get('username', None)
         self.conf.password = kwargs.get('password', None)
-        # by header
-        self.auth_header_name = "Authorization"
+        # defaults
+        self.auth_header_name = None
         self.auth_header_value = None
         # by token
         if self.token:
+            self.auth_header_name = "Authorization"
             self.auth_header_value = "Token " + self.token
         # by HTTP basic
         auth_basic = kwargs.get('auth_basic', False)
         if auth_basic:
+            self.auth_header_name = "Authorization"
             self.auth_header_value = "Basic " + base64.b64encode(token.encode()).decode()
         # by username, password
         if self.conf.username and self.conf.password:

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -72,8 +72,10 @@ class _BaseClient(object):
 
         self.conf.username = kwargs.get('username', None)
         self.conf.password = kwargs.get('password', None)
-        # by token
+        # by header
         self.auth_header_name = "Authorization"
+        self.auth_header_value = None
+        # by token
         if self.token:
             self.auth_header_value = "Token " + self.token
         # by HTTP basic

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ test_requires = [
     'randomize>=0.13',
     'pytest>=5.0.0',
     'httpretty==1.0.5',
-    'psutil>=5.6.3'
+    'psutil>=5.6.3',
+    'aioresponses>=0.7.3'
 ]
 
 extra_requires = [

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -4,6 +4,7 @@ import os
 import threading
 import unittest
 
+import httpretty
 import pytest
 from urllib3.exceptions import NewConnectionError, HTTPError
 
@@ -175,11 +176,6 @@ class InfluxDBClientTest(unittest.TestCase):
             write_api.write(bucket="my-bucket", org="my-org", record="mem,tag=a value=1")
         self.assertIn("Failed to establish a new connection", str(e.value))
 
-    def test_init_without_token(self):
-        self.client = InfluxDBClient("http://localhost:8086")
-        self.assertIsNotNone(self.client)
-        self.client.query_api().query("buckets()", "my-org")
-
 
 class InfluxDBClientTestIT(BaseTest):
     httpRequest = []
@@ -247,6 +243,24 @@ class InfluxDBClientTestIT(BaseTest):
         self.httpd = http.server.HTTPServer(('localhost', 0), ProxyHTTPRequestHandler)
         self.httpd_thread = threading.Thread(target=self.httpd.serve_forever)
         self.httpd_thread.start()
+
+
+class InfluxDBClientTestMock(unittest.TestCase):
+
+    def setUp(self) -> None:
+        httpretty.enable()
+        httpretty.reset()
+
+    def tearDown(self) -> None:
+        if self.influxdb_client:
+            self.influxdb_client.close()
+        httpretty.disable()
+
+    def test_init_without_token(self):
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/query", status=200, body="")
+        self.influxdb_client = InfluxDBClient("http://localhost")
+        self.assertIsNotNone(self.influxdb_client)
+        self.influxdb_client.query_api().query("buckets()", "my-org")
 
 
 class ServerWithSelfSingedSSL(http.server.SimpleHTTPRequestHandler):

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -175,6 +175,10 @@ class InfluxDBClientTest(unittest.TestCase):
             write_api.write(bucket="my-bucket", org="my-org", record="mem,tag=a value=1")
         self.assertIn("Failed to establish a new connection", str(e.value))
 
+    def test_init_without_token(self):
+        self.client = InfluxDBClient("http://localhost:8086")
+        self.assertIsNotNone(self.client)
+
 
 class InfluxDBClientTestIT(BaseTest):
     httpRequest = []

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -178,6 +178,7 @@ class InfluxDBClientTest(unittest.TestCase):
     def test_init_without_token(self):
         self.client = InfluxDBClient("http://localhost:8086")
         self.assertIsNotNone(self.client)
+        self.client.query_api().query("buckets()", "my-org")
 
 
 class InfluxDBClientTestIT(BaseTest):

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -242,6 +242,7 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
     async def test_init_without_token(self):
         await self.client.close()
         self.client = InfluxDBClientAsync("http://localhost:8086")
+        await self.client.query_api().query("buckets()", "my-org")
 
     async def _prepare_data(self, measurement: str):
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3)

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -238,6 +238,11 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         self.client = InfluxDBClientAsync(url="http://localhost:8086", username="my-user", password="my-password", debug=True)
         await self.client.query_api().query("buckets()", "my-org")
 
+    @async_test
+    async def test_init_without_token(self):
+        await self.client.close()
+        self.client = InfluxDBClientAsync("http://localhost:8086")
+
     async def _prepare_data(self, measurement: str):
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3)
         _point2 = Point(measurement).tag("location", "New York").field("temperature", 24.3)

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 
 import pytest
+from aioresponses import aioresponses
 
 from influxdb_client import Point, WritePrecision
 from influxdb_client.client.exceptions import InfluxDBError
@@ -239,9 +240,11 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         await self.client.query_api().query("buckets()", "my-org")
 
     @async_test
-    async def test_init_without_token(self):
+    @aioresponses()
+    async def test_init_without_token(self, mocked):
+        mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body='')
         await self.client.close()
-        self.client = InfluxDBClientAsync("http://localhost:8086")
+        self.client = InfluxDBClientAsync("http://localhost")
         await self.client.query_api().query("buckets()", "my-org")
 
     async def _prepare_data(self, measurement: str):


### PR DESCRIPTION
Closes #442

## Proposed Changes

Fixed initialisation of the client without auth credentials:

```python
from influxdb_client import InfluxDBClient

client = InfluxDBClient("localhost:8086")
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
