### PR TITLE
feat(query): improve Query UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#440](https://github.com/influxdata/influxdb-client-python/pull/440): Add possibility to specify timestamp column and its timezone [DataFrame]
+1. [#450](https://github.com/influxdata/influxdb-client-python/pull/450): Improve Query UX - simplify serialization to JSON and add possibility to serialize query results as a flattened list of values
 
 ### Bug Fixes
 1. [#457](https://github.com/influxdata/influxdb-client-python/pull/457): Formatting nanoseconds to Flux AST

--- a/README.rst
+++ b/README.rst
@@ -615,7 +615,7 @@ Queries
 The result retrieved by `QueryApi <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/query_api.py>`_  could be formatted as a:
 
 1. Flux data structure: `FluxTable <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L5>`_, `FluxColumn <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L22>`_ and `FluxRecord <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L31>`_
-2. `csv.reader <https://docs.python.org/3.4/library/csv.html#reader-objects>`__ which will iterate over CSV lines
+2. :class:`~influxdb_client.client.flux_table.CSVIterator` which will iterate over CSV lines
 3. Raw unprocessed results as a ``str`` iterator
 4. `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
 

--- a/README.rst
+++ b/README.rst
@@ -615,10 +615,9 @@ Queries
 The result retrieved by `QueryApi <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/query_api.py>`_  could be formatted as a:
 
 1. Flux data structure: `FluxTable <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L5>`_, `FluxColumn <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L22>`_ and `FluxRecord <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/flux_table.py#L31>`_
-2. Query bind parameters
-3. `csv.reader <https://docs.python.org/3.4/library/csv.html#reader-objects>`__ which will iterate over CSV lines
-4. Raw unprocessed results as a ``str`` iterator
-5. `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
+2. `csv.reader <https://docs.python.org/3.4/library/csv.html#reader-objects>`__ which will iterate over CSV lines
+3. Raw unprocessed results as a ``str`` iterator
+4. `Pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
 
 The API also support streaming ``FluxRecord`` via `query_stream <https://github.com/influxdata/influxdb-client-python/blob/master/influxdb_client/client/query_api.py#L77>`_, see example below:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,9 @@ QueryApi
 .. autoclass:: influxdb_client.client.flux_table.TableList
    :members:
 
+.. autoclass:: influxdb_client.client.flux_table.CSVIterator
+   :members:
+
 WriteApi
 """"""""
 .. autoclass:: influxdb_client.WriteApi

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,9 @@ QueryApi
 .. autoclass:: influxdb_client.client.flux_table.FluxRecord
    :members:
 
+.. autoclass:: influxdb_client.client.flux_table.TableList
+   :members:
+
 WriteApi
 """"""""
 .. autoclass:: influxdb_client.WriteApi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
-sys.path.insert(0, os.path.abspath('..'))
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/examples/query_response_to_json.py
+++ b/examples/query_response_to_json.py
@@ -19,8 +19,5 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
     """
     Serialize to JSON
     """
-    import json
-    from influxdb_client.client.flux_table import FluxStructureEncoder
-
-    output = json.dumps(tables, cls=FluxStructureEncoder, indent=2)
+    output = tables.to_json(indent=5)
     print(output)

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -18,6 +18,7 @@ from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode, Flu
 from influxdb_client.client.flux_table import FluxRecord, TableList, CSVIterator
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.client.util.helpers import get_org_query_param
+from influxdb_client.client.warnings import MissingPivotFunction
 from influxdb_client.client.write.dataframe_serializer import DataframeSerializer
 from influxdb_client.rest import _UTF_8_encoding
 
@@ -300,7 +301,7 @@ class _BaseQueryApi(object):
             from influxdb_client.client.query_api import QueryOptions
             return QueryOptions(profilers=self._influxdb_client.profilers)
 
-    def _create_query(self, query, dialect=default_dialect, params: dict = None):
+    def _create_query(self, query, dialect=default_dialect, params: dict = None, **kwargs):
         query_options = self._get_query_options()
         profilers = query_options.profilers if query_options is not None else None
         q = Query(query=query, dialect=dialect, extern=_BaseQueryApi._build_flux_ast(params, profilers))
@@ -310,6 +311,9 @@ class _BaseQueryApi(object):
             print("Profiler: query")
             print("===============")
             print(query)
+
+        if kwargs.get('dataframe_query', False):
+            MissingPivotFunction.print_warning(query)
 
         return q
 

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -17,7 +17,7 @@ from influxdb_client import Configuration, Dialect, Query, OptionStatement, Vari
     Duration, StringLiteral, ArrayExpression, ImportDeclaration, MemberExpression, MemberAssignment, File, \
     WriteService, QueryService, DeleteService, DeletePredicateRequest
 from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode, FluxCsvParser, FluxSerializationMode
-from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.flux_table import FluxRecord, TableList
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.client.util.helpers import get_org_query_param
 from influxdb_client.client.write.dataframe_serializer import DataframeSerializer
@@ -196,9 +196,9 @@ class _BaseQueryApi(object):
     """Base implementation for Queryable API."""
 
     def _to_tables(self, response, query_options=None, response_metadata_mode:
-                   FluxResponseMetadataMode = FluxResponseMetadataMode.full) -> List[FluxTable]:
+                   FluxResponseMetadataMode = FluxResponseMetadataMode.full) -> TableList:
         """
-        Parse HTTP response to FluxTables.
+        Parse HTTP response to TableList.
 
         :param response: HTTP response from an HTTP client. Expected type: `urllib3.response.HTTPResponse`.
         """
@@ -207,9 +207,9 @@ class _BaseQueryApi(object):
         return _parser.table_list()
 
     async def _to_tables_async(self, response, query_options=None, response_metadata_mode:
-                               FluxResponseMetadataMode = FluxResponseMetadataMode.full) -> List[FluxTable]:
+                               FluxResponseMetadataMode = FluxResponseMetadataMode.full) -> TableList:
         """
-        Parse HTTP response to FluxTables.
+        Parse HTTP response to TableList.
 
         :param response: HTTP response from an HTTP client. Expected type: `aiohttp.client_reqrep.ClientResponse`.
         """

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -2,13 +2,11 @@
 from __future__ import absolute_import
 
 import base64
-import codecs
 import configparser
-import csv
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Iterator, List, Generator, Any, Union, Iterable, AsyncGenerator
+from typing import List, Generator, Any, Union, Iterable, AsyncGenerator
 
 from urllib3 import HTTPResponse
 
@@ -17,7 +15,7 @@ from influxdb_client import Configuration, Dialect, Query, OptionStatement, Vari
     Duration, StringLiteral, ArrayExpression, ImportDeclaration, MemberExpression, MemberAssignment, File, \
     WriteService, QueryService, DeleteService, DeletePredicateRequest
 from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode, FluxCsvParser, FluxSerializationMode
-from influxdb_client.client.flux_table import FluxRecord, TableList
+from influxdb_client.client.flux_table import FluxRecord, TableList, CSVIterator
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.client.util.helpers import get_org_query_param
 from influxdb_client.client.write.dataframe_serializer import DataframeSerializer
@@ -218,9 +216,9 @@ class _BaseQueryApi(object):
                 pass
             return parser.table_list()
 
-    def _to_csv(self, response: HTTPResponse) -> Iterator[List[str]]:
+    def _to_csv(self, response: HTTPResponse) -> CSVIterator:
         """Parse HTTP response to CSV."""
-        return csv.reader(codecs.iterdecode(response, _UTF_8_encoding))
+        return CSVIterator(response)
 
     def _to_flux_record_stream(self, response, query_options=None,
                                response_metadata_mode: FluxResponseMetadataMode = FluxResponseMetadataMode.full) -> \

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -7,7 +7,7 @@ import csv as csv_parser
 from enum import Enum
 from typing import List
 
-from influxdb_client.client.flux_table import FluxTable, FluxColumn, FluxRecord
+from influxdb_client.client.flux_table import FluxTable, FluxColumn, FluxRecord, TableList
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.rest import _UTF_8_encoding
 
@@ -71,7 +71,7 @@ class FluxCsvParser(object):
                          Acceptable types: `urllib3.response.HTTPResponse`, `aiohttp.client_reqrep.ClientResponse`.
         """
         self._response = response
-        self.tables = []
+        self.tables = TableList()
         self._serialization_mode = serialization_mode
         self._response_metadata_mode = response_metadata_mode
         self._data_frame_index = data_frame_index
@@ -344,12 +344,12 @@ class FluxCsvParser(object):
         return any(filter(lambda column: (column.default_value == "_profiler" and column.label == "result"),
                           table.columns))
 
-    def table_list(self) -> List[FluxTable]:
+    def table_list(self) -> TableList:
         """Get the list of flux tables."""
         if not self._profilers:
             return self.tables
         else:
-            return list(filter(lambda table: not self._is_profiler_table(table), self.tables))
+            return TableList(filter(lambda table: not self._is_profiler_table(table), self.tables))
 
     def _print_profiler_info(self, flux_record: FluxRecord):
         if flux_record.get_measurement().startswith("profiler/"):

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -4,6 +4,7 @@ Flux employs a basic data model built from basic data types.
 The data model consists of tables, records, columns.
 """
 from json import JSONEncoder
+from typing import List
 
 
 class FluxStructure:
@@ -137,3 +138,9 @@ class FluxRecord(FluxStructure):
     def __repr__(self):
         """Format for inspection."""
         return f"<{type(self).__name__}: field={self.values.get('_field')}, value={self.values.get('_value')}>"
+
+
+class TableList(List[FluxTable]):
+    """List of 'FluxTable's with additionally functional to better handle of query result."""
+
+    pass

--- a/influxdb_client/client/invokable_scripts_api.py
+++ b/influxdb_client/client/invokable_scripts_api.py
@@ -165,16 +165,29 @@ class InvokableScriptsApi(_BaseQueryApi):
         """
         Invoke synchronously a script and return Pandas DataFrame.
 
-        Note that if a script returns tables with differing schemas than the client generates
-        a DataFrame for each of them.
-
         The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
+
+        .. note:: If the ``script`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
 
         :param str script_id: The ID of the script to invoke. (required)
         :param List[str] data_frame_index: The list of columns that are used as DataFrame index.
         :param params: bind parameters
-        :return: Pandas DataFrame.
-        """
+        :return: :class:`~DataFrame` or :class:`~List[DataFrame]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+        """  # noqa: E501
         _generator = self.invoke_script_data_frame_stream(script_id=script_id,
                                                           params=params,
                                                           data_frame_index=data_frame_index)
@@ -186,12 +199,27 @@ class InvokableScriptsApi(_BaseQueryApi):
 
         The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
 
+        .. note:: If the ``script`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
+
         :param str script_id: The ID of the script to invoke. (required)
         :param List[str] data_frame_index: The list of columns that are used as DataFrame index.
         :param params: bind parameters
-        :return: Stream of Pandas DataFrames.
-        :rtype: Generator['pd.DataFrame']
-        """
+        :return: :class:`~Generator[DataFrame]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+        """  # noqa: E501
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,
                                     script_invocation_params=ScriptInvocationParams(params=params),

--- a/influxdb_client/client/invokable_scripts_api.py
+++ b/influxdb_client/client/invokable_scripts_api.py
@@ -66,9 +66,72 @@ class InvokableScriptsApi(_BaseQueryApi):
 
         :param str script_id: The ID of the script to invoke. (required)
         :param params: bind parameters
-        :return: List of FluxTable.
+        :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
+                 :class:`~influxdb_client.client.flux_table.TableList`
         :rtype: TableList
-        """
+
+        Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.TableList.to_values`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            with InfluxDBClient(url="https://us-west-2-1.aws.cloud2.influxdata.com", token="my-token", org="my-org") as client:
+
+                # Query: using Table structure
+                tables = client.invokable_scripts_api().invoke_script(script_id="script-id")
+
+                # Serialize to values
+                output = tables.to_values(columns=['location', '_time', '_value'])
+                print(output)
+                
+        .. code-block:: python
+
+            [
+                ['New York', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 24.3],
+                ['Prague', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 25.3],
+                ...
+            ]
+
+        Serialization the query results to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            with InfluxDBClient(url="https://us-west-2-1.aws.cloud2.influxdata.com", token="my-token", org="my-org") as client:
+
+                # Query: using Table structure
+                tables = client.invokable_scripts_api().invoke_script(script_id="script-id")
+
+                # Serialize to JSON
+                output = tables.to_json(indent=5)
+                print(output)
+                
+        .. code-block:: javascript
+
+            [
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:00.897825+00:00",
+                    "region": "north",
+                     "_field": "usage",
+                    "_value": 15
+                },
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:01.897825+00:00",
+                    "region": "west",
+                     "_field": "usage",
+                    "_value": 10
+                },
+                ...
+            ]                
+        """  # noqa: E501
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,
                                     script_invocation_params=ScriptInvocationParams(params=params),
@@ -148,6 +211,32 @@ class InvokableScriptsApi(_BaseQueryApi):
         :param str script_id: The ID of the script to invoke. (required)
         :param params: bind parameters
         :return: :class:`~Iterator[List[str]]` wrapped into :class:`~influxdb_client.client.flux_table.CSVIterator`
+        :rtype: CSVIterator
+
+        Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.CSVIterator.to_values`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+
+                # Query: using CSV iterator
+                csv_iterator = client.invokable_scripts_api().invoke_script_csv(script_id="script-id")
+
+                # Serialize to values
+                output = csv_iterator.to_values()
+                print(output)
+
+        .. code-block:: python
+
+            [
+                ['', 'result', 'table', '_start', '_stop', '_time', '_value', '_field', '_measurement', 'location']
+                ['', '', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
+                ['', '', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
+                ...
+            ]                
+
         """  # noqa: E501
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,

--- a/influxdb_client/client/invokable_scripts_api.py
+++ b/influxdb_client/client/invokable_scripts_api.py
@@ -11,7 +11,7 @@ from influxdb_client import Script, InvokableScriptsService, ScriptCreateRequest
     ScriptInvocationParams
 from influxdb_client.client._base import _BaseQueryApi
 from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode
-from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.flux_table import FluxRecord, TableList
 
 
 class InvokableScriptsApi(_BaseQueryApi):
@@ -58,16 +58,16 @@ class InvokableScriptsApi(_BaseQueryApi):
         """
         return self._invokable_scripts_service.get_scripts(**kwargs).scripts
 
-    def invoke_script(self, script_id: str, params: dict = None) -> List['FluxTable']:
+    def invoke_script(self, script_id: str, params: dict = None) -> TableList:
         """
-        Invoke synchronously a script and return result as a List['FluxTable'].
+        Invoke synchronously a script and return result as a TableList.
 
         The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
 
         :param str script_id: The ID of the script to invoke. (required)
         :param params: bind parameters
         :return: List of FluxTable.
-        :rtype: list[FluxTable]
+        :rtype: TableList
         """
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,

--- a/influxdb_client/client/invokable_scripts_api.py
+++ b/influxdb_client/client/invokable_scripts_api.py
@@ -11,7 +11,7 @@ from influxdb_client import Script, InvokableScriptsService, ScriptCreateRequest
     ScriptInvocationParams
 from influxdb_client.client._base import _BaseQueryApi
 from influxdb_client.client.flux_csv_parser import FluxResponseMetadataMode
-from influxdb_client.client.flux_table import FluxRecord, TableList
+from influxdb_client.client.flux_table import FluxRecord, TableList, CSVIterator
 
 
 class InvokableScriptsApi(_BaseQueryApi):
@@ -139,17 +139,16 @@ class InvokableScriptsApi(_BaseQueryApi):
         return self._to_data_frame_stream(data_frame_index, response, query_options=None,
                                           response_metadata_mode=FluxResponseMetadataMode.only_names)
 
-    def invoke_script_csv(self, script_id: str, params: dict = None) -> Iterator[List[str]]:
+    def invoke_script_csv(self, script_id: str, params: dict = None) -> CSVIterator:
         """
-        Invoke synchronously a script and return result as a CSV iterator.
+        Invoke synchronously a script and return result as a CSV iterator. Each iteration returns a row of the CSV file.
 
         The bind parameters referenced in the script are substitutes with `params` key-values sent in the request body.
 
         :param str script_id: The ID of the script to invoke. (required)
         :param params: bind parameters
-        :return: The returned object is an iterator. Each iteration returns a row of the CSV file
-                 (which can span multiple input lines).
-        """
+        :return: :class:`~Iterator[List[str]]` wrapped into :class:`~influxdb_client.client.flux_table.CSVIterator`
+        """  # noqa: E501
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,
                                     script_invocation_params=ScriptInvocationParams(params=params),

--- a/influxdb_client/client/invokable_scripts_api.py
+++ b/influxdb_client/client/invokable_scripts_api.py
@@ -84,7 +84,7 @@ class InvokableScriptsApi(_BaseQueryApi):
                 # Serialize to values
                 output = tables.to_values(columns=['location', '_time', '_value'])
                 print(output)
-                
+
         .. code-block:: python
 
             [
@@ -107,7 +107,7 @@ class InvokableScriptsApi(_BaseQueryApi):
                 # Serialize to JSON
                 output = tables.to_json(indent=5)
                 print(output)
-                
+
         .. code-block:: javascript
 
             [
@@ -130,7 +130,7 @@ class InvokableScriptsApi(_BaseQueryApi):
                     "_value": 10
                 },
                 ...
-            ]                
+            ]
         """  # noqa: E501
         response = self._invokable_scripts_service \
             .post_scripts_id_invoke(script_id=script_id,
@@ -235,7 +235,7 @@ class InvokableScriptsApi(_BaseQueryApi):
                 ['', '', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
                 ['', '', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
                 ...
-            ]                
+            ]
 
         """  # noqa: E501
         response = self._invokable_scripts_service \

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -75,7 +75,7 @@ class QueryApi(_BaseQueryApi):
                 ['', '', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
                 ['', '', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
                 ...
-            ]                
+            ]
 
         If you would like to turn off `Annotated CSV header's <https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/>`_ you can use following code:
 
@@ -91,14 +91,14 @@ class QueryApi(_BaseQueryApi):
 
                 for csv_line in csv_iterator:
                     print(csv_line)
-                    
+
         .. code-block:: python
 
             [
                 ['', '_result', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
                 ['', '_result', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
                 ...
-            ]  
+            ]
         """  # noqa: E501
         org = self._org_param(org)
         response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params),
@@ -150,7 +150,7 @@ class QueryApi(_BaseQueryApi):
                 # Serialize to values
                 output = tables.to_values(columns=['location', '_time', '_value'])
                 print(output)
-                
+
         .. code-block:: python
 
             [
@@ -173,7 +173,7 @@ class QueryApi(_BaseQueryApi):
                 # Serialize to JSON
                 output = tables.to_json(indent=5)
                 print(output)
-                
+
         .. code-block:: javascript
 
             [
@@ -196,7 +196,7 @@ class QueryApi(_BaseQueryApi):
                     "_value": 10
                 },
                 ...
-            ]                
+            ]
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -84,7 +84,22 @@ class QueryApi(_BaseQueryApi):
         :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
                  :class:`~influxdb_client.client.flux_table.TableList`
 
-        The query results can be serialized to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
+        Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.TableList.to_values`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+
+                # Query: using Table structure
+                tables = client.query_api().query('from(bucket:"my-bucket") |> range(start: -10m)')
+
+                # Serialize to values
+                output = tables.to_values(columns=['location', '_time', '_value'])
+                print(output)
+
+        Serialization the query results to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
 
         .. code-block:: python
 

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -203,7 +203,8 @@ class QueryApi(_BaseQueryApi):
         """
         org = self._org_param(org)
 
-        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),
+        response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params,
+                                                                                dataframe_query=True),
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
 
         return self._to_data_frame_stream(data_frame_index=data_frame_index,

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -8,7 +8,7 @@ from typing import List, Generator, Any, Callable
 
 from influxdb_client import Dialect
 from influxdb_client.client._base import _BaseQueryApi
-from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.flux_table import FluxRecord, TableList
 
 
 class QueryOptions(object):
@@ -73,9 +73,9 @@ class QueryApi(_BaseQueryApi):
 
         return result
 
-    def query(self, query: str, org=None, params: dict = None) -> List['FluxTable']:
+    def query(self, query: str, org=None, params: dict = None) -> TableList:
         """
-        Execute synchronous Flux query and return result as a List['FluxTable'].
+        Execute synchronous Flux query and return result as a TableList.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -48,6 +48,7 @@ class QueryApi(_BaseQueryApi):
         :param dialect: csv dialect format
         :param params: bind parameters
         :return: :class:`~Iterator[List[str]]` wrapped into :class:`~influxdb_client.client.flux_table.CSVIterator`
+        :rtype: CSVIterator
 
         Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.CSVIterator.to_values`:
 
@@ -64,6 +65,18 @@ class QueryApi(_BaseQueryApi):
                 output = csv_iterator.to_values()
                 print(output)
 
+        .. code-block:: python
+
+            [
+                ['#datatype', 'string', 'long', 'dateTime:RFC3339', 'dateTime:RFC3339', 'dateTime:RFC3339', 'double', 'string', 'string', 'string']
+                ['#group', 'false', 'false', 'true', 'true', 'false', 'false', 'true', 'true', 'true']
+                ['#default', '_result', '', '', '', '', '', '', '', '']
+                ['', 'result', 'table', '_start', '_stop', '_time', '_value', '_field', '_measurement', 'location']
+                ['', '', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
+                ['', '', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
+                ...
+            ]                
+
         If you would like to turn off `Annotated CSV header's <https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/>`_ you can use following code:
 
         .. code-block:: python
@@ -78,6 +91,14 @@ class QueryApi(_BaseQueryApi):
 
                 for csv_line in csv_iterator:
                     print(csv_line)
+                    
+        .. code-block:: python
+
+            [
+                ['', '_result', '0', '2022-06-16', '2022-06-16', '2022-06-16', '24.3', 'temperature', 'my_measurement', 'New York']
+                ['', '_result', '1', '2022-06-16', '2022-06-16', '2022-06-16', '25.3', 'temperature', 'my_measurement', 'Prague']
+                ...
+            ]  
         """  # noqa: E501
         org = self._org_param(org)
         response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params),
@@ -113,6 +134,7 @@ class QueryApi(_BaseQueryApi):
         :param params: bind parameters
         :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
                  :class:`~influxdb_client.client.flux_table.TableList`
+        :rtype: TableList
 
         Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.TableList.to_values`:
 
@@ -128,6 +150,14 @@ class QueryApi(_BaseQueryApi):
                 # Serialize to values
                 output = tables.to_values(columns=['location', '_time', '_value'])
                 print(output)
+                
+        .. code-block:: python
+
+            [
+                ['New York', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 24.3],
+                ['Prague', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 25.3],
+                ...
+            ]
 
         Serialization the query results to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
 
@@ -143,6 +173,30 @@ class QueryApi(_BaseQueryApi):
                 # Serialize to JSON
                 output = tables.to_json(indent=5)
                 print(output)
+                
+        .. code-block:: javascript
+
+            [
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:00.897825+00:00",
+                    "region": "north",
+                     "_field": "usage",
+                    "_value": 15
+                },
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:01.897825+00:00",
+                    "region": "west",
+                     "_field": "usage",
+                    "_value": 10
+                },
+                ...
+            ]                
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -63,6 +63,21 @@ class QueryApi(_BaseQueryApi):
                 # Serialize to values
                 output = csv_iterator.to_values()
                 print(output)
+
+        If you would like to turn off `Annotated CSV header's <https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/>`_ you can use following code:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient, Dialect
+
+            with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+
+                # Query: using CSV iterator
+                csv_iterator = client.query_api().query_csv('from(bucket:"my-bucket") |> range(start: -10m)',
+                                                            dialect=Dialect(header=False, annotations=[]))
+
+                for csv_line in csv_iterator:
+                    print(csv_line)
         """  # noqa: E501
         org = self._org_param(org)
         response = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params),

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -74,16 +74,31 @@ class QueryApi(_BaseQueryApi):
         return result
 
     def query(self, query: str, org=None, params: dict = None) -> TableList:
-        """
-        Execute synchronous Flux query and return result as a TableList.
+        """Execute synchronous Flux query and return result as a :class:`~influxdb_client.client.flux_table.FluxTable` list.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
                                       Take the ``ID``, ``Name`` or ``Organization``.
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param params: bind parameters
-        :return:
-        """
+        :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
+                 :class:`~influxdb_client.client.flux_table.TableList`
+
+        The query results can be serialized to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+
+                # Query: using Table structure
+                tables = client.query_api().query('from(bucket:"my-bucket") |> range(start: -10m)')
+
+                # Serialize to JSON
+                output = tables.to_json(indent=5)
+                print(output)
+        """  # noqa: E501
         org = self._org_param(org)
 
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params),

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -226,8 +226,7 @@ class QueryApi(_BaseQueryApi):
         """
         Execute synchronous Flux query and return Pandas DataFrame.
 
-        Note that if a query returns tables with differing schemas than the client generates
-        a DataFrame for each of them.
+        .. note:: If the ``query`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
@@ -235,17 +234,30 @@ class QueryApi(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
-        :return: DataFrame or List of DataFrames
-        """
+        :return: :class:`~DataFrame` or :class:`~List[DataFrame]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+        """  # noqa: E501
         _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index, params=params)
         return self._to_data_frames(_generator)
 
     def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
         """
-        Execute synchronous Flux query and return stream of Pandas DataFrame as a Generator['pd.DataFrame'].
+        Execute synchronous Flux query and return stream of Pandas DataFrame as a :class:`~Generator[DataFrame]`.
 
-        Note that if a query returns tables with differing schemas than the client generates
-        a DataFrame for each of them.
+        .. note:: If the ``query`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
@@ -253,8 +265,22 @@ class QueryApi(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
-        :return:
-        """
+        :return: :class:`~Generator[DataFrame]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+        """  # noqa: E501
         org = self._org_param(org)
 
         response = self._query_api.post_query(org=org, query=self._create_query(query, self.default_dialect, params,

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -24,14 +24,30 @@ class QueryApiAsync(_BaseQueryApi):
 
     async def query(self, query: str, org=None, params: dict = None) -> TableList:
         """
-        Execute asynchronous Flux query and return result as a :class:`~influxdb_client.client.flux_table.TableList`.
+        Execute asynchronous Flux query and return result as a :class:`~influxdb_client.client.flux_table.FluxTable` list.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
                                       Take the ``ID``, ``Name`` or ``Organization``.
                                       If not specified the default value from ``InfluxDBClientAsync.org`` is used.
         :param params: bind parameters
-        :return: List of :class:`~influxdb_client.client.flux_table.FluxTable`.
+        :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
+                 :class:`~influxdb_client.client.flux_table.TableList`
+
+        The query results can be serialized to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
+
+        .. code-block:: python
+
+            from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
+
+            async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", org="my-org") as client:
+                # Query: using Table structure
+                tables = await client.query_api().query('from(bucket:"my-bucket") |> range(start: -10m)')
+
+                # Serialize to JSON
+                output = tables.to_json(indent=5)
+                print(output)
+
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -129,8 +129,7 @@ class QueryApiAsync(_BaseQueryApi):
         """
         Execute asynchronous Flux query and return :class:`~pandas.core.frame.DataFrame`.
 
-        Note that if a query returns tables with differing schemas than the client generates
-        a DataFrame for each of them.
+        .. note:: If the ``query`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
@@ -138,8 +137,22 @@ class QueryApiAsync(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClientAsync.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
-        :return: :class:`~pandas.core.frame.DataFrame` or List of :class:`~pandas.core.frame.DataFrame`
-        """
+        :return: :class:`~DataFrame` or :class:`~List[DataFrame]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+        """  # noqa: E501
         _generator = await self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index,
                                                         params=params)
 
@@ -154,8 +167,7 @@ class QueryApiAsync(_BaseQueryApi):
         """
         Execute asynchronous Flux query and return stream of :class:`~pandas.core.frame.DataFrame` as an AsyncGenerator[:class:`~pandas.core.frame.DataFrame`].
 
-        Note that if a query returns tables with differing schemas than the client generates
-        a DataFrame for each of them.
+        .. note:: If the ``query`` returns tables with differing schemas than the client generates a :class:`~DataFrame` for each of them.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;
@@ -163,7 +175,21 @@ class QueryApiAsync(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClientAsync.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
-        :return: AsyncGenerator[:class:`~pandas.core.frame.DataFrame`]
+        :return: :class:`AsyncGenerator[:class:`DataFrame`]`
+
+        .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
+
+            .. code-block:: text
+
+                from(bucket:"my-bucket")
+                    |> range(start: -5m, stop: now())
+                    |> filter(fn: (r) => r._measurement == "mem")
+                    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+            For more info see:
+                - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+                - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+                - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -33,6 +33,7 @@ class QueryApiAsync(_BaseQueryApi):
         :param params: bind parameters
         :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
                  :class:`~influxdb_client.client.flux_table.TableList`
+        :rtype: TableList
 
         Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.TableList.to_values`:
 
@@ -49,6 +50,14 @@ class QueryApiAsync(_BaseQueryApi):
                 output = tables.to_values(columns=['location', '_time', '_value'])
                 print(output)
 
+        .. code-block:: python
+
+            [
+                ['New York', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 24.3],
+                ['Prague', datetime.datetime(2022, 6, 7, 11, 3, 22, 917593, tzinfo=tzutc()), 25.3],
+                ...
+            ]
+
         Serialization the query results to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
 
         .. code-block:: python
@@ -62,7 +71,30 @@ class QueryApiAsync(_BaseQueryApi):
                 # Serialize to JSON
                 output = tables.to_json(indent=5)
                 print(output)
+                
+        .. code-block:: javascript
 
+            [
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:00.897825+00:00",
+                    "region": "north",
+                     "_field": "usage",
+                    "_value": 15
+                },
+                {
+                    "_measurement": "mem",
+                    "_start": "2021-06-23T06:50:11.897825+00:00",
+                    "_stop": "2021-06-25T06:50:11.897825+00:00",
+                    "_time": "2020-02-27T16:20:01.897825+00:00",
+                    "region": "west",
+                     "_field": "usage",
+                    "_value": 10
+                },
+                ...
+            ]                
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -136,7 +136,8 @@ class QueryApiAsync(_BaseQueryApi):
         org = self._org_param(org)
 
         response = await self._query_api.post_query_async(org=org,
-                                                          query=self._create_query(query, self.default_dialect, params),
+                                                          query=self._create_query(query, self.default_dialect, params,
+                                                                                   dataframe_query=True),
                                                           async_req=False, _preload_content=False,
                                                           _return_http_data_only=True)
 

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -6,7 +6,7 @@ Flux is InfluxData’s functional data scripting language designed for querying,
 from typing import List, AsyncGenerator
 
 from influxdb_client.client._base import _BaseQueryApi
-from influxdb_client.client.flux_table import FluxTable, FluxRecord
+from influxdb_client.client.flux_table import FluxRecord, TableList
 from influxdb_client.client.query_api import QueryOptions
 from influxdb_client.rest import _UTF_8_encoding
 
@@ -22,9 +22,9 @@ class QueryApiAsync(_BaseQueryApi):
         """
         super().__init__(influxdb_client=influxdb_client, query_options=query_options)
 
-    async def query(self, query: str, org=None, params: dict = None) -> List['FluxTable']:
+    async def query(self, query: str, org=None, params: dict = None) -> TableList:
         """
-        Execute asynchronous Flux query and return result as a List[:class:`~influxdb_client.client.flux_table.FluxTable`].
+        Execute asynchronous Flux query and return result as a :class:`~influxdb_client.client.flux_table.TableList`.
 
         :param query: the Flux query
         :param str, Organization org: specifies the organization for executing the query;

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -34,7 +34,22 @@ class QueryApiAsync(_BaseQueryApi):
         :return: :class:`~influxdb_client.client.flux_table.FluxTable` list wrapped into
                  :class:`~influxdb_client.client.flux_table.TableList`
 
-        The query results can be serialized to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
+        Serialization the query results to flattened list of values via :func:`~influxdb_client.client.flux_table.TableList.to_values`:
+
+        .. code-block:: python
+
+            from influxdb_client import InfluxDBClient
+
+            async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", org="my-org") as client:
+
+                # Query: using Table structure
+                tables = await client.query_api().query('from(bucket:"my-bucket") |> range(start: -10m)')
+
+                # Serialize to values
+                output = tables.to_values(columns=['location', '_time', '_value'])
+                print(output)
+
+        Serialization the query results to JSON via :func:`~influxdb_client.client.flux_table.TableList.to_json`:
 
         .. code-block:: python
 

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -71,7 +71,7 @@ class QueryApiAsync(_BaseQueryApi):
                 # Serialize to JSON
                 output = tables.to_json(indent=5)
                 print(output)
-                
+
         .. code-block:: javascript
 
             [
@@ -94,7 +94,7 @@ class QueryApiAsync(_BaseQueryApi):
                     "_value": 10
                 },
                 ...
-            ]                
+            ]
         """  # noqa: E501
         org = self._org_param(org)
 

--- a/influxdb_client/client/warnings.py
+++ b/influxdb_client/client/warnings.py
@@ -1,0 +1,31 @@
+"""The warnings message definition."""
+import warnings
+
+
+class MissingPivotFunction(UserWarning):
+    """User warning about missing pivot() function."""
+
+    @staticmethod
+    def print_warning(query: str):
+        """Print warning about missing pivot() function and how to deal with that."""
+        if 'fieldsAsCols' in query or 'pivot' in query:
+            return
+
+        message = f"""The query doesn't contains the pivot() function.
+
+The result will not be shape to optimal processing by pandas.DataFrame. Use the pivot() function by:
+
+    {query} |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+
+You can disable this warning by:
+    import warnings
+    from influxdb_client.client.warnings import MissingPivotFunction
+
+    warnings.simplefilter("ignore", MissingPivotFunction)
+
+For more info see:
+    - https://docs.influxdata.com/resources/videos/pivots-in-flux/
+    - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
+    - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
+"""
+        warnings.warn(message, MissingPivotFunction)

--- a/influxdb_client/client/warnings.py
+++ b/influxdb_client/client/warnings.py
@@ -13,7 +13,7 @@ class MissingPivotFunction(UserWarning):
 
         message = f"""The query doesn't contains the pivot() function.
 
-The result will not be shape to optimal processing by pandas.DataFrame. Use the pivot() function by:
+The result will not be shaped to optimal processing by pandas.DataFrame. Use the pivot() function by:
 
     {query} |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
 

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -1,3 +1,4 @@
+import json
 import math
 import unittest
 from io import BytesIO
@@ -6,7 +7,7 @@ from urllib3 import HTTPResponse
 
 from influxdb_client.client.flux_csv_parser import FluxCsvParser, FluxSerializationMode, FluxQueryException, \
     FluxResponseMetadataMode
-from influxdb_client.client.flux_table import FluxStructureEncoder
+from influxdb_client.client.flux_table import FluxStructureEncoder, TableList
 
 
 class FluxCsvParserTest(unittest.TestCase):
@@ -275,9 +276,64 @@ class FluxCsvParserTest(unittest.TestCase):
         self.assertEqual('11', tables[0].records[0]['value1'])
         self.assertEqual('west', tables[0].records[0]['region'])
 
+    def test_parse_to_json(self):
+        data = """#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string
+#group,false,false,true,true,true,true,true,true,false,false,false
+#default,_result,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,C,north,50,40,abc
+
+#group,false,false,true,true,true,true,true,true,true,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,double
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,language,license,name,owner,le,_value
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,0,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,10,0
+
+"""
+
+        tables = self._parse_to_tables(data=data)
+        parsed = json.loads(tables.to_json())
+        self.assertEqual(4, parsed.__len__())
+
+        self.assertEqual(11, parsed[0].__len__())
+        self.assertEqual(11, parsed[0]['value1'])
+        self.assertEqual("test", parsed[0]['value_str'])
+
+        self.assertEqual(11, parsed[1].__len__())
+        self.assertEqual(40, parsed[1]['value1'])
+        self.assertEqual("abc", parsed[1]['value_str'])
+
+        self.assertEqual(12, parsed[2].__len__())
+        self.assertEqual(0, parsed[2]['le'])
+        self.assertEqual("influxdata", parsed[2]['owner'])
+
+        self.assertEqual(12, parsed[3].__len__())
+        self.assertEqual(10, parsed[3]['le'])
+        self.assertEqual("influxdata", parsed[3]['owner'])
+
+    def test_parse_to_json_columns(self):
+        data = """#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string
+#group,false,false,true,true,true,true,true,true,false,false,false
+#default,_result,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,C,north,50,40,abc
+"""
+
+        tables = self._parse_to_tables(data=data)
+        parsed = json.loads(tables.to_json(columns=['region', 'size']))
+        self.assertEqual(2, parsed.__len__())
+
+        self.assertEqual(1, parsed[0].__len__())
+        self.assertEqual("west", parsed[0]['region'])
+        self.assertEqual(1, parsed[1].__len__())
+        self.assertEqual("north", parsed[1]['region'])
+
     @staticmethod
     def _parse_to_tables(data: str, serialization_mode=FluxSerializationMode.tables,
-                         response_metadata_mode=FluxResponseMetadataMode.full):
+                         response_metadata_mode=FluxResponseMetadataMode.full) -> TableList:
         _parser = FluxCsvParserTest._parse(data, serialization_mode, response_metadata_mode=response_metadata_mode)
         list(_parser.generator())
         tables = _parser.tables

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -188,7 +188,7 @@ class FluxCsvParserTest(unittest.TestCase):
         self.assertEqual(math.inf, tables[0].records[10]["le"])
         self.assertEqual(-math.inf, tables[0].records[11]["le"])
 
-    def test_to_json(self):
+    def test_to_json_by_encoder(self):
         data = "#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string\n" \
                "#group,false,false,true,true,true,true,false,false,true\n" \
                "#default,_result,,,,,,,,\n" \
@@ -330,6 +330,31 @@ class FluxCsvParserTest(unittest.TestCase):
         self.assertEqual("west", parsed[0]['region'])
         self.assertEqual(1, parsed[1].__len__())
         self.assertEqual("north", parsed[1]['region'])
+
+    def test_parse_to_values(self):
+        data = """#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string
+#group,false,false,true,true,true,true,true,true,false,false,false
+#default,_result,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,host,region,_value2,value,value_str
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test
+,,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,C,north,50,40,abc
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string
+#group,false,false,true,true,true,true,true,true,false,false,false
+#default,_result,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,host,region,_value2,value,value_str
+,,1,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,B,south,121,18,test
+,,1,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,D,south,50,22,abc
+"""
+
+        tables = self._parse_to_tables(data=data)
+        parsed = tables.to_values(['region', 'host', 'not_exits', 'value'])
+        self.assertEqual(4, parsed.__len__())
+
+        self.assertEqual(['west', 'A', None, 11], parsed[0])
+        self.assertEqual(['north', 'C', None, 40], parsed[1])
+        self.assertEqual(['south', 'B', None, 18], parsed[2])
+        self.assertEqual(['south', 'D', None, 22], parsed[3])
 
     @staticmethod
     def _parse_to_tables(data: str, serialization_mode=FluxSerializationMode.tables,

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -9,6 +9,7 @@ from aioresponses import aioresponses
 from influxdb_client import Point, WritePrecision
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
+from influxdb_client.client.warnings import MissingPivotFunction
 from tests.base_test import generate_name
 
 
@@ -139,6 +140,39 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         self.assertEqual('Prague', dataframe['location'][1])
 
     @async_test
+    async def test_query_data_frame_with_warning(self):
+        measurement = generate_name("measurement")
+        await self._prepare_data(measurement)
+        query = f'''
+                    from(bucket:"my-bucket") 
+                        |> range(start: -10m)
+                        |> filter(fn: (r) => r["_measurement"] == "{measurement}") 
+                '''
+        query_api = self.client.query_api()
+
+        with pytest.warns(MissingPivotFunction) as warnings:
+            dataframe = await query_api.query_data_frame(query)
+            self.assertIsNotNone(dataframe)
+        self.assertEqual(1, len(warnings))
+
+    @async_test
+    async def test_query_data_frame_without_warning(self):
+        measurement = generate_name("measurement")
+        await self._prepare_data(measurement)
+        query = f'''
+                    from(bucket:"my-bucket") 
+                        |> range(start: -10m)
+                        |> filter(fn: (r) => r["_measurement"] == "{measurement}") 
+                        |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+                '''
+        query_api = self.client.query_api()
+
+        with pytest.warns(None) as warnings:
+            dataframe = await query_api.query_data_frame(query)
+            self.assertIsNotNone(dataframe)
+        self.assertEqual(0, len(warnings))
+
+    @async_test
     async def test_write_response_type(self):
         measurement = generate_name("measurement")
         point = Point(measurement).tag("location", "Prague").field("temperature", 25.3)
@@ -236,7 +270,8 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
     @async_test
     async def test_username_password_authorization(self):
         await self.client.close()
-        self.client = InfluxDBClientAsync(url="http://localhost:8086", username="my-user", password="my-password", debug=True)
+        self.client = InfluxDBClientAsync(url="http://localhost:8086", username="my-user", password="my-password",
+                                          debug=True)
         await self.client.query_api().query("buckets()", "my-org")
 
     @async_test


### PR DESCRIPTION
Closes #445 
Closes #446

## Proposed Changes

1. `query()` function returns `TableList` instead of `List['FluxTable']`, `query_csv()` function returns `CSVIterator` instead of `csv.reader` => we are able to add additional functions for better procession of the query results 
1. Query results can be easily serialised into `list` of values and JSON:
   ![image](https://user-images.githubusercontent.com/455137/174022192-e0498b02-2611-4620-a9bb-f3221492bea2.png)
1. CSV query results can be easily serialised into `list` of values and optionally spit out the headers: 
  ![image](https://user-images.githubusercontent.com/455137/174024867-3b4bb398-71d8-47a5-8f69-62f56f9aa7b6.png)
1. `query_data_frame()` function contains warning and updated doc about using `pivot() function` to optimal shaping of query results
    ![image](https://user-images.githubusercontent.com/455137/174062262-91ab3685-2412-4f7c-a3b3-45bcff910231.png)
    ```python
    from influxdb_client import InfluxDBClient

    with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org", debug=False) as client:
        # query to data_frame
        data_frame = client.query_api().query_data_frame('''from(bucket:"my-bucket") |> range(start: -10m)''')

        print(data_frame.to_string())
    ```
    ```
    /influxdb-client-python/influxdb_client/client/warnings.py:31: MissingPivotFunction: The query doesn't contains the pivot() function.

    The result will not be shaped to optimal processing by pandas.DataFrame. Use the pivot() function by:

        from(bucket:"my-bucket") |> range(start: -10m) |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")

    You can disable this warning by:
        import warnings
        from influxdb_client.client.warnings import MissingPivotFunction

        warnings.simplefilter("ignore", MissingPivotFunction)

    For more info see:
        - https://docs.influxdata.com/resources/videos/pivots-in-flux/
        - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
        - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/

        result  table                           _start                            _stop                            _time  _value       _field    _measurement  location
    0  _result      0 2022-06-16 12:17:07.240362+00:00 2022-06-16 12:27:07.240362+00:00 2022-06-16 12:24:17.125455+00:00    24.3  temperature  my_measurement  New York
    1  _result      1 2022-06-16 12:17:07.240362+00:00 2022-06-16 12:27:07.240362+00:00 2022-06-16 12:24:17.125455+00:00    25.3  temperature  my_measurement    Prague

    ```
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)