### PR TITLE
fix: formatting nanoseconds to Flux AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#440](https://github.com/influxdata/influxdb-client-python/pull/440): Add possibility to specify timestamp column and its timezone [DataFrame]
 
+### Bug Fixes
+1. [#457](https://github.com/influxdata/influxdb-client-python/pull/457): Formatting nanoseconds to Flux AST
+
 ### Dependencies
 1. [#449](https://github.com/influxdata/influxdb-client-python/pull/449): Remove `pytz` library
 

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -341,7 +341,9 @@ class _BaseQueryApi(object):
             return FloatLiteral("FloatLiteral", value)
         elif isinstance(value, datetime):
             value = get_date_helper().to_utc(value)
-            return DateTimeLiteral("DateTimeLiteral", value.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
+            nanoseconds = getattr(value, 'nanosecond', 0)
+            fraction = f'{(value.microsecond * 1000 + nanoseconds):09d}'
+            return DateTimeLiteral("DateTimeLiteral", value.strftime('%Y-%m-%dT%H:%M:%S.') + fraction + 'Z')
         elif isinstance(value, timedelta):
             _micro_delta = int(value / timedelta(microseconds=1))
             if _micro_delta < 0:

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -132,7 +132,7 @@ class SimpleQueryTest(BaseTest):
                         },
                         "init": {
                             "type": "DateTimeLiteral",
-                            "value": "2021-03-20T15:59:10.607352Z"
+                            "value": "2021-03-20T15:59:10.607352000Z"
                         },
                         "type": "VariableAssignment"
                     },
@@ -150,7 +150,7 @@ class SimpleQueryTest(BaseTest):
                         },
                         "init": {
                             "type": "DateTimeLiteral",
-                            "value": "2021-03-20T15:59:10.607352Z"
+                            "value": "2021-03-20T15:59:10.607352000Z"
                         },
                         "type": "VariableAssignment"
                     },
@@ -513,6 +513,22 @@ class SimpleQueryTest(BaseTest):
                            'host': 'kozel.local',
                            'available': 5727718400, 'free': 35330048,
                            'used': 11452150784})
+
+    def test_time_to_ast(self):
+        from influxdb_client.extras import pd
+        import dateutil.parser
+
+        literals = [
+            (pd.Timestamp('1996-02-25T21:20:00.001001231Z'), '1996-02-25T21:20:00.001001231Z'),
+            (dateutil.parser.parse('1996-02-25T21:20:00.001001231Z'), '1996-02-25T21:20:00.001001000Z'),
+            (dateutil.parser.parse('1996-02-25'), '1996-02-25T00:00:00.000000000Z'),
+            (datetime.datetime(2021, 5, 24, 8, 40, 44, 785000, tzinfo=timezone.utc), '2021-05-24T08:40:44.785000000Z'),
+        ]
+
+        for literal in literals:
+            ast = QueryApi._build_flux_ast({'date': literal[0]})
+            self.assertEqual('DateTimeLiteral', ast.body[0].assignment.init.type)
+            self.assertEqual(literal[1], ast.body[0].assignment.init.value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #455 

## Proposed Changes

Fixed formatting `datetime` with nanoseconds to Flux AST.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
