### PR TITLE
feat: add possibility to initialize client by json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.31.0 [unreleased]
 
+### Features
+1. [#467](https://github.com/influxdata/influxdb-client-python/pull/467): Add possibility to initialize client by json file
+
 ### Bug Fixes
 1. [#462](https://github.com/influxdata/influxdb-client-python/pull/462): Redact the `Authorization` HTTP header from log
 

--- a/README.rst
+++ b/README.rst
@@ -572,7 +572,7 @@ In a `init <https://docs.python.org/3/library/configparser.html>`_ configuration
     customer = California Miner
     data_center = ${env.data_center}
 
-You can also use a `TOML <https://toml.io/en/>`_ format for the configuration file.
+You can also use a `TOML <https://toml.io/en/>`_  or a`JSON <https://www.json.org/json-en.html>`_ format for the configuration file.
 
 Via Environment Properties
 __________________________

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -108,7 +108,7 @@ class _BaseClient(object):
         is_json = False
         try:
             config.read(config_file)
-        except configparser.ParsingError as e:
+        except configparser.ParsingError:
             with open(config_file) as json_file:
                 import json
                 config = json.load(json_file)

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -84,6 +84,7 @@ class InfluxDBClient(_BaseClient):
         The supported formats:
             - https://docs.python.org/3/library/configparser.html
             - https://toml.io/en/
+            - https://www.json.org/json-en.html
 
         Configuration options:
             - url
@@ -131,6 +132,24 @@ class InfluxDBClient(_BaseClient):
                 id = "132-987-655"
                 customer = "California Miner"
                 data_center = "${env.data_center}"
+
+        config.json example::
+
+            {
+                "url": "http://localhost:8086",
+                "token": "my-token",
+                "org": "my-org",
+                "active": true,
+                "timeout": 6000,
+                "connection_pool_maxsize": 55,
+                "auth_basic": false,
+                "profilers": "query, operator",
+                "tags": {
+                    "id": "132-987-655",
+                    "customer": "California Miner",
+                    "data_center": "${env.data_center}"
+                }
+            }
 
         """
         return super(InfluxDBClient, cls)._from_config_file(config_file=config_file, debug=debug,

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -100,6 +100,7 @@ class InfluxDBClientAsync(_BaseClient):
         The supported formats:
             - https://docs.python.org/3/library/configparser.html
             - https://toml.io/en/
+            - https://www.json.org/json-en.html
 
         Configuration options:
             - url
@@ -147,6 +148,24 @@ class InfluxDBClientAsync(_BaseClient):
                 id = "132-987-655"
                 customer = "California Miner"
                 data_center = "${env.data_center}"
+
+        config.json example::
+
+            {
+                "url": "http://localhost:8086",
+                "token": "my-token",
+                "org": "my-org",
+                "active": true,
+                "timeout": 6000,
+                "connection_pool_maxsize": 55,
+                "auth_basic": false,
+                "profilers": "query, operator",
+                "tags": {
+                    "id": "132-987-655",
+                    "customer": "California Miner",
+                    "data_center": "${env.data_center}"
+                }
+            }
 
         """
         return super(InfluxDBClientAsync, cls)._from_config_file(config_file=config_file, debug=debug,

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,15 @@
+{
+  "url": "http://localhost:8086",
+  "token": "my-token",
+  "org": "my-org",
+  "active": true,
+  "timeout": 6000,
+  "connection_pool_maxsize": 55,
+  "auth_basic": false,
+  "profilers": "query, operator",
+  "tags": {
+    "id": "132-987-655",
+    "customer": "California Miner",
+    "data_center": "${env.data_center}"
+  }
+}

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -65,6 +65,11 @@ class InfluxDBClientTest(unittest.TestCase):
 
         self.assertConfig()
 
+    def test_init_from_json_file(self):
+        self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.json')
+
+        self.assertConfig()
+
     def assertConfig(self):
         self.assertEqual("http://localhost:8086", self.client.url)
         self.assertEqual("my-org", self.client.org)


### PR DESCRIPTION
Closes #444

## Proposed Changes

Added possibility to initialize client by json file.

The format of the `json` file is same as is produced by `influx config`: 

```console
influx config --json
```

```json
{
        "url": "http://localhost:8086",
        "token": "my-token",
        "org": "my-org",
        "active": true
}

```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
