### PR TITLE
fix: parsing date fails due to thread race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.32.0[unreleased]
 
+### Bug Fixes
+1. [#477](https://github.com/influxdata/influxdb-client-python/pull/477): parsing date fails due to thread race
+
 ## 1.31.0 [2022-07-29]
 
 ### Features


### PR DESCRIPTION
Closes #471 

## Proposed Changes

Two python threads can call get_date_helper() simultaneously, causing a
partially-contstructed DateHelper object to be returned to the caller.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)