### PR TITLE
chore: add makefile to repo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+count = True
+max-line-length = 120
+
+# W504: Line break occurred after a binary operator
+ignore = W504

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: help
 .PHONY: clean
 clean:
 	rm -f .coverage coverage.xml writer.pickle
-	rm -rf .pytest_cache build dist htmlcov test-reports
+	rm -rf .pytest_cache build dist htmlcov test-reports docs/_build
 
 .PHONY: docs
 docs:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: all
+all: help
+
+.PHONY: clean
+clean:
+	rm -f .coverage coverage.xml writer.pickle
+	rm -rf .pytest_cache build dist htmlcov test-reports
+
+.PHONY: help
+help:
+	@echo 'Makefile Targets'
+	@echo '  clean      clean up local files'
+	@echo '  help       print this help output'
+	@echo '  install    install library as editable with all dependencies'
+	@echo '  lint       execute flake8 against source code'
+	@echo '  test       execute all tests'
+
+.PHONY: install
+install:
+	pip install --editable ".[test,extra,ciso,async]"
+
+.PHONY: lint
+lint:
+	flake8 setup.py influxdb_client/
+
+.PHONY: test
+test:
+	pytest tests \
+		--cov=./ \
+		--cov-report html:htmlcov \
+		--cov-report xml:coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,15 @@ clean:
 	rm -f .coverage coverage.xml writer.pickle
 	rm -rf .pytest_cache build dist htmlcov test-reports
 
+.PHONY: docs
+docs:
+	cd docs && python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
+
 .PHONY: help
 help:
 	@echo 'Makefile Targets'
 	@echo '  clean      clean up local files'
+	@echo '  docs       build docs locally'
 	@echo '  help       print this help output'
 	@echo '  install    install library as editable with all dependencies'
 	@echo '  lint       execute flake8 against source code'

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,14 @@ requires = [
 ]
 
 test_requires = [
+    'flake8>=5.0.3',
     'coverage>=4.0.3',
     'nose>=1.3.7',
     'pluggy>=0.3.1',
     'py>=1.4.31',
     'randomize>=0.13',
     'pytest>=5.0.0',
+    'pytest-cov>=3.0.0',
     'httpretty==1.0.5',
     'psutil>=5.6.3',
     'aioresponses>=0.7.3'
@@ -49,7 +51,7 @@ NAME = "influxdb_client"
 
 meta = {}
 with open(Path(__file__).parent / 'influxdb_client' / 'version.py') as f:
-    exec('\n'.join(l for l in f if l.startswith('VERSION')), meta)
+    exec('\n'.join(line for line in f if line.startswith('VERSION')), meta)
 
 setup(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ test_requires = [
     'pytest-cov>=3.0.0',
     'httpretty==1.0.5',
     'psutil>=5.6.3',
-    'aioresponses>=0.7.3'
+    'aioresponses>=0.7.3',
+    'sphinx==1.8.5',
+    'sphinx_rtd_theme',
+    'jinja2==3.0.3'
 ]
 
 extra_requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py3
-
-[flake8]
-ignore = W504
-count = True
-max-line-length = 120
-# W504: Line break occurred after a binary operator


### PR DESCRIPTION
This adds a simple makefile to be able to install dependencies quickly,
install the library locally as editable for quick development,
lint the necessary files, and run tests with coverage.

It also removes the tox file in favor of a dedicated flake8 file to not
give the impression we are using tox in any way.

My hope is for this to be used during development, but want to
look at replacing some other commands during CI/test with this
as well to keep things in sync better. For now, this is primarily
to act as a helper to developers.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
