### PR TITLE
fix: querying data if the `debug` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 :warning: This release drop supports for Python 3.6. As of 2021-12-23, 3.6 has reached the end-of-life phase of its release cycle. 3.6.15 was the final security release. For more info see: https://peps.python.org/pep-0494/#lifespan
 
+### Bug Fixes
+1. [#483](https://github.com/influxdata/influxdb-client-python/pull/483): Querying data if the `debug` is enabled
+
 ### Dependencies
 1. [#472](https://github.com/influxdata/influxdb-client-python/pull/472): Update `RxPY` to `4.0.4`
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -86,7 +86,7 @@ class FluxCsvParser(object):
     def __enter__(self):
         """Initialize CSV reader."""
         # response can be exhausted by logger, so we have to use data that has already been read
-        if hasattr(self._response, 'closed') and hasattr(self._response, 'data') and self._response.closed:
+        if hasattr(self._response, 'closed') and self._response.closed:
             from io import StringIO
             self._reader = csv_parser.reader(StringIO(self._response.data.decode(_UTF_8_encoding)))
         else:

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -85,7 +85,12 @@ class FluxCsvParser(object):
 
     def __enter__(self):
         """Initialize CSV reader."""
-        self._reader = csv_parser.reader(codecs.iterdecode(self._response, _UTF_8_encoding))
+        # response can be exhausted by logger, so we have to use data that has already been read
+        if hasattr(self._response, 'closed') and hasattr(self._response, 'data') and self._response.closed:
+            from io import StringIO
+            self._reader = csv_parser.reader(StringIO(self._response.data.decode(_UTF_8_encoding)))
+        else:
+            self._reader = csv_parser.reader(codecs.iterdecode(self._response, _UTF_8_encoding))
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -234,6 +234,16 @@ class InfluxDBClientTestIT(BaseTest):
         self.client = InfluxDBClient(url=self.host, username="my-user", password="my-password", debug=True)
         self.client.query_api().query("buckets()", "my-org")
 
+    def test_query_and_debug(self):
+        self.client.close()
+        self.client = InfluxDBClient(url=self.host, token="my-token", debug=True)
+        # Query API
+        results = self.client.query_api().query("buckets()", "my-org")
+        self.assertIn("my-bucket", list(map(lambda record: record["name"], results[0].records)))
+        # Bucket API
+        results = self.client.buckets_api().find_buckets()
+        self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))
+
     def _start_proxy_server(self):
         import http.server
         import urllib.request

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -1,3 +1,4 @@
+import codecs
 import http.server
 import json
 import logging
@@ -237,9 +238,12 @@ class InfluxDBClientTestIT(BaseTest):
     def test_query_and_debug(self):
         self.client.close()
         self.client = InfluxDBClient(url=self.host, token="my-token", debug=True)
-        # Query API
+        # Query
         results = self.client.query_api().query("buckets()", "my-org")
         self.assertIn("my-bucket", list(map(lambda record: record["name"], results[0].records)))
+        # Query RAW
+        results = self.client.query_api().query_raw("buckets()", "my-org")
+        self.assertIn("my-bucket", codecs.decode(results.data))
         # Bucket API
         results = self.client.buckets_api().find_buckets()
         self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -8,7 +8,7 @@ from io import StringIO
 import pytest
 from aioresponses import aioresponses
 
-from influxdb_client import Point, WritePrecision
+from influxdb_client import Point, WritePrecision, BucketsService
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 from influxdb_client.client.warnings import MissingPivotFunction
@@ -296,6 +296,18 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         await self.client.query_api().query("buckets()", "my-org")
 
         self.assertIn("Authorization: ***", log_stream.getvalue())
+
+    @async_test
+    async def test_query_and_debug(self):
+        await self.client.close()
+        self.client = InfluxDBClientAsync(url="http://localhost:8086", token="my-token", debug=True)
+        # Query API
+        results = await self.client.query_api().query("buckets()", "my-org")
+        self.assertIn("my-bucket", list(map(lambda record: record["name"], results[0].records)))
+        # Bucket API
+        buckets_service = BucketsService(api_client=self.client.api_client)
+        results = await buckets_service.get_buckets()
+        self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))
 
     async def _prepare_data(self, measurement: str):
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3)

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -301,9 +301,12 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
     async def test_query_and_debug(self):
         await self.client.close()
         self.client = InfluxDBClientAsync(url="http://localhost:8086", token="my-token", debug=True)
-        # Query API
+        # Query
         results = await self.client.query_api().query("buckets()", "my-org")
         self.assertIn("my-bucket", list(map(lambda record: record["name"], results[0].records)))
+        # Query RAW
+        results = await self.client.query_api().query_raw("buckets()", "my-org")
+        self.assertIn("my-bucket", results)
         # Bucket API
         buckets_service = BucketsService(api_client=self.client.api_client)
         results = await buckets_service.get_buckets()


### PR DESCRIPTION
Closes #480

## Proposed Changes

The HTTP response can be exhausted by logger, so we have to use data that has already been read.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
