### PR TITLE
fix: creating `Tasks` with `import` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Bug Fixes
 1. [#483](https://github.com/influxdata/influxdb-client-python/pull/483): Querying data if the `debug` is enabled
 1. [#477](https://github.com/influxdata/influxdb-client-python/pull/477): Parsing date fails due to thread race
-1. [#486](https://github.com/influxdata/influxdb-client-python/pull/486): Fix bug when serializing DataFrames that might occur if you're inserting NaN values and have columns starting with digits.
+1. [#486](https://github.com/influxdata/influxdb-client-python/pull/486): Serializing DataFrames with columns starting with digits
+1. [#491](https://github.com/influxdata/influxdb-client-python/pull/491): Creating `Tasks` with `import` statements
 
 ### Dependencies
 1. [#472](https://github.com/influxdata/influxdb-client-python/pull/472): Update `RxPY` to `4.0.4`

--- a/influxdb_client/client/tasks_api.py
+++ b/influxdb_client/client/tasks_api.py
@@ -64,11 +64,7 @@ class TasksApi(object):
             repetition += "cron: "
             repetition += '"' + cron + '"'
 
-        from_index = flux.index("from")
-        flux_with_options = \
-            flux[0:from_index] + \
-            'option task = {{name: "{}", {}}} \n\n'.format(name, repetition) + \
-            flux[from_index:]
+        flux_with_options = '{} \n\noption task = {{name: "{}", {}}}'.format(flux, name, repetition)
         task.flux = flux_with_options
 
         return task

--- a/influxdb_client/client/tasks_api.py
+++ b/influxdb_client/client/tasks_api.py
@@ -4,7 +4,6 @@ Process and analyze your data with tasks in the InfluxDB task engine.
 Use tasks (scheduled Flux queries) to input a data stream and then analyze, modify, and act on the data accordingly.
 """
 
-
 import datetime
 from typing import List
 
@@ -65,7 +64,11 @@ class TasksApi(object):
             repetition += "cron: "
             repetition += '"' + cron + '"'
 
-        flux_with_options = 'option task = {{name: "{}", {}}} \n {}'.format(name, repetition, flux)
+        from_index = flux.index("from")
+        flux_with_options = \
+            flux[0:from_index] + \
+            'option task = {{name: "{}", {}}} \n\n'.format(name, repetition) + \
+            flux[from_index:]
         task.flux = flux_with_options
 
         return task
@@ -151,10 +154,10 @@ class TasksApi(object):
         Retrieve list of run records for a task.
 
         :param task_id: task id
-        :param str after: returns runs after specified ID
-        :param int limit: the number of runs to return
-        :param datetime after_time: filter runs to those scheduled after this time, RFC3339
-        :param datetime before_time: filter runs to those scheduled before this time, RFC3339
+        :key str after: returns runs after specified ID
+        :key int limit: the number of runs to return
+        :key datetime after_time: filter runs to those scheduled after this time, RFC3339
+        :key datetime before_time: filter runs to those scheduled before this time, RFC3339
         """
         return self._service.get_tasks_id_runs(task_id=task_id, **kwargs).runs
 

--- a/tests/test_TasksApi.py
+++ b/tests/test_TasksApi.py
@@ -121,7 +121,7 @@ class TasksApiTest(BaseTest):
         self.assertEqual(task.status, "active")
         self.assertEqual(task.every, "1h")
         self.assertEqual(task.cron, None)
-        self.assertTrue(task.flux.endswith(TASK_FLUX))
+        self.assertTrue(task.flux.startswith(TASK_FLUX))
 
     def test_create_task_cron(self):
         task_name = self.generate_name("it task")
@@ -137,7 +137,7 @@ class TasksApiTest(BaseTest):
         self.assertEqual(task.cron, "0 2 * * *")
         # self.assertEqualIgnoringWhitespace(task.flux, flux)
 
-        self.assertTrue(task.flux.endswith(TASK_FLUX))
+        self.assertTrue(task.flux.startswith(TASK_FLUX))
         # self.assertEqual(task.links, "active")
 
         links = task.links
@@ -165,8 +165,8 @@ class TasksApiTest(BaseTest):
         self.assertEqual(task.org_id, self.organization.id)
         self.assertEqual(task.status, "active")
         self.assertEqual(task.cron, "10 0 * * * *")
-        self.assertTrue(task.flux.startswith('import "http"\n\noption task = '))
-        self.assertTrue(task.flux.endswith('    |> aggregateWindow(every: 1h, fn: mean)'))
+        self.assertTrue(task.flux.startswith(task_flux))
+        self.assertTrue(task.flux.splitlines()[-1].startswith('option task = '))
 
     def test_find_task_by_id(self):
         task_name = self.generate_name("it task")
@@ -199,12 +199,12 @@ class TasksApiTest(BaseTest):
         cron_task = self.tasks_api.create_task_cron(task_name, TASK_FLUX, "0 2 * * *", self.organization.id)
 
         flux = '''
+        {flux}
+        
         option task = {{
             name: "{task_name}",
             every: 3m
         }}
-        
-        {flux}
         '''.format(task_name=task_name, flux=TASK_FLUX)
 
         cron_task.cron = None


### PR DESCRIPTION
Closes #490 

## Proposed Changes

Fixed creating `Task` with import statement:

```python
task_flux = 'import "http"\n\n' \
            'from(bucket: "iot_center")\n' \
            '    |> range(start: -30d)\n' \
            '    |> filter(fn: (r) => r._measurement == "environment")\n' \
            '    |> aggregateWindow(every: 1h, fn: mean)'
task = self.tasks_api.create_task_cron("my-name", task_flux, "10 0 * * * *", self.organization.id)
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
