### PR TITLE
chore: add warning for measurement name starts with hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Others
 1. [#472](https://github.com/influxdata/influxdb-client-python/pull/472): Drop supports for Python 3.6
+1. [#495](https://github.com/influxdata/influxdb-client-python/pull/495): Add warning for measurement name starts with `#`
 
 ### Documentation
 1. [#397](https://github.com/influxdata/influxdb-client-python/pull/397): Add an example: How to use RxPY to prepare batches by maximum bytes count

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -187,7 +187,7 @@ class Point(object):
 
 The output Line protocol will be interpret as a comment by InfluxDB. For more info see:
     - https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/#comments
-            """
+"""
             warnings.warn(message, SyntaxWarning)
         _tags = _append_tags(self._tags)
         _fields = _append_fields(self._fields)

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -1,6 +1,7 @@
 """Point data structure to represent LineProtocol."""
 
 import math
+import warnings
 from builtins import int
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -181,6 +182,13 @@ class Point(object):
          :param precision: required precision of LineProtocol. If it's not set then use the precision from ``Point``.
         """
         _measurement = _escape_key(self._name, _ESCAPE_MEASUREMENT)
+        if _measurement.startswith("#"):
+            message = f"""The measurement name '{_measurement}' start with '#'.
+
+The output Line protocol will be interpret as a comment by InfluxDB. For more info see:
+    - https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/#comments
+            """
+            warnings.warn(message, SyntaxWarning)
         _tags = _append_tags(self._tags)
         _fields = _append_fields(self._fields)
         if not _fields:
@@ -249,26 +257,26 @@ def _append_fields(fields):
     return f"{','.join(_return)}"
 
 
-def _append_time(time, write_precision):
+def _append_time(time, write_precision) -> str:
     if time is None:
         return ''
     return f" {int(_convert_timestamp(time, write_precision))}"
 
 
-def _escape_key(tag, escape_list=None):
+def _escape_key(tag, escape_list=None) -> str:
     if escape_list is None:
         escape_list = _ESCAPE_KEY
     return str(tag).translate(escape_list)
 
 
-def _escape_tag_value(value):
+def _escape_tag_value(value) -> str:
     ret = _escape_key(value)
     if ret.endswith('\\'):
         ret += ' '
     return ret
 
 
-def _escape_string(value):
+def _escape_string(value) -> str:
     return str(value).translate(_ESCAPE_STRING)
 
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -4,6 +4,7 @@ import unittest
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 
+import pytest
 from dateutil import tz
 
 from influxdb_client import Point, WritePrecision
@@ -493,6 +494,12 @@ class PointTest(unittest.TestCase):
                                 record_tag_keys=["location", "version"],
                                 record_field_keys=["pressure", "temperature"])
         self.assertEqual("custom_sensor_id,location=warehouse_125 pressure=125i", point.to_line_protocol())
+
+    def test_name_start_with_hash(self):
+        point = Point.measurement("#hash_start").tag("location", "europe").field("level", 2.2)
+        with pytest.warns(SyntaxWarning) as warnings:
+            self.assertEqual('#hash_start,location=europe level=2.2', point.to_line_protocol())
+        self.assertEqual(1, len(warnings))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #473

## Proposed Changes

Added warning for measurement name starts with `#`:

> The measurement name '#my_measurement' start with '#'.
>
> The output Line protocol will be interpret as a comment by InfluxDB. For more info see:
>    - https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/#comments

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
