### PR TITLE
fix: parsing response with new line in column [async/await]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.33.0 [unreleased]
 
+### Bug Fixes
+1. [#497](https://github.com/influxdata/influxdb-client-python/pull/497): Parsing InfluxDB response with new line character in CSV column [async/await]
+
 ## 1.32.0 [2022-08-25]
 
 :warning: This release drop supports for Python 3.6. As of 2021-12-23, 3.6 has reached the end-of-life phase of its release cycle. 3.6.15 was the final security release. For more info see: https://peps.python.org/pep-0494/#lifespan

--- a/README.rst
+++ b/README.rst
@@ -1371,12 +1371,12 @@ How to use Asyncio
 .. marker-asyncio-start
 
 Starting from version 1.27.0 for Python 3.7+ the ``influxdb-client`` package supports ``async/await`` based on
-`asyncio <https://docs.python.org/3/library/asyncio.html>`_ and `aiohttp <https://docs.aiohttp.org>`_.
-You can install ``aiohttp`` directly:
+`asyncio <https://docs.python.org/3/library/asyncio.html>`_, `aiohttp <https://docs.aiohttp.org>`_ and `aiocsv <https://pypi.org/project/aiocsv/>`_.
+You can install ``aiohttp`` and ``aiocsv`` directly:
 
  .. code-block:: bash
 
-    $ python -m pip install influxdb-client aiohttp
+    $ python -m pip install influxdb-client aiohttp aiocsv
 
 or use the ``[async]`` extra:
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ ciso_requires = [
 ]
 
 async_requires = [
-    'aiohttp>=3.8.1'
+    'aiohttp>=3.8.1',
+    'aiocsv>=1.2.2'
 ]
 
 with open('README.rst', 'r') as f:


### PR DESCRIPTION
Closes #496

## Proposed Changes

Use [aiocsv](https://pypi.org/project/aiocsv/) for parsing CSV response from InfluxDB.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
