### PR TITLE
docs: add deprecation warning for `WriteType.asynchronous`

### DIFF
--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -3,6 +3,7 @@
 # coding: utf-8
 import logging
 import os
+import warnings
 from collections import defaultdict
 from datetime import timedelta
 from enum import Enum
@@ -272,6 +273,14 @@ class WriteApi(_BaseWriteApi):
         else:
             self._subject = None
             self._disposable = None
+
+        if self._write_options.write_type is WriteType.asynchronous:
+            message = f"""The 'WriteType.asynchronous' is deprecated and will be removed in future major version. 
+            
+You can use native asynchronous version of the client:
+- https://influxdb-client.readthedocs.io/en/stable/usage.html#how-to-use-asyncio
+        """
+            warnings.warn(message, DeprecationWarning)
 
     def write(self, bucket: str, org: str = None,
               record: Union[

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -275,8 +275,8 @@ class WriteApi(_BaseWriteApi):
             self._disposable = None
 
         if self._write_options.write_type is WriteType.asynchronous:
-            message = f"""The 'WriteType.asynchronous' is deprecated and will be removed in future major version. 
-            
+            message = """The 'WriteType.asynchronous' is deprecated and will be removed in future major version.
+
 You can use native asynchronous version of the client:
 - https://influxdb-client.readthedocs.io/en/stable/usage.html#how-to-use-asyncio
         """


### PR DESCRIPTION
## Proposed Changes

The `WriteType.asynchronous` should be deprecated because we already have correctly implement async/await version of the client - https://influxdb-client.readthedocs.io/en/stable/usage.html#how-to-use-asyncio.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
