### PR TITLE
fix(tests): compatibility with Pandas 1.5

### DIFF
--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -313,7 +313,7 @@ class DataSerializerTest(unittest.TestCase):
         data_frame = pd.DataFrame(data={
                                       'value': [1, 2],
                                 },
-                                index=pd.period_range(start='2020-04-05 01:00+00:00', freq='H', periods=2))
+                                index=pd.period_range(start='2020-04-05 01:00', freq='H', periods=2))
 
         points = data_frame_to_list_of_points(data_frame=data_frame,
                                               point_settings=PointSettings(),


### PR DESCRIPTION
Related to https://app.circleci.com/pipelines/github/influxdata/influxdb-client-python/2046/workflows/8fdf747c-83b7-4fed-a1e7-647c216f211f

## Proposed Changes

Use correct `start` bound for `PeriodIndex` to be compatible with Pandas 1.5.

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/455137/191587132-3fd6cac7-5834-45bc-9c15-f559bf034357.png">

- https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
