### PR TITLE
chore(ci): use Python 3.8 image instead of Docker:19 to build lambda layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ workflows:
       - check-twine
       - check-examples
       - check-sphinx
-      - check-aws-lambda-layer
       - tests-python:
           name: test-3.7
       - tests-python:
@@ -207,3 +206,4 @@ workflows:
                 - master
     jobs:
       - tests-python
+      - check-aws-lambda-layer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
             python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
   check-aws-lambda-layer:
     docker:
-      - image: docker:19
+      - image: "cimg/python:3.8"
     steps:
       - checkout
       - setup_remote_docker
@@ -178,6 +178,7 @@ workflows:
       - check-twine
       - check-examples
       - check-sphinx
+      - check-aws-lambda-layer
       - tests-python:
           name: test-3.7
       - tests-python:
@@ -206,4 +207,3 @@ workflows:
                 - master
     jobs:
       - tests-python
-      - check-aws-lambda-layer


### PR DESCRIPTION
## Proposed Changes

Use Python 3.8 image instead of Docker:19 to clarify which version of the Docker is used to build image.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
