### PR TITLE
feat: allow to use client's optional configs for initialization from file or environment properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.34.0 [unreleased]
 
+### Features
+1. [#510](https://github.com/influxdata/influxdb-client-python/pull/510): Allow to use client's optional configs for initialization from file or environment properties
 
 ## 1.33.0 [2022-09-29]
 

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -102,7 +102,7 @@ class _BaseClient(object):
         return "unknown"
 
     @classmethod
-    def _from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False):
+    def _from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
         config = configparser.ConfigParser()
         is_json = False
         try:
@@ -169,10 +169,10 @@ class _BaseClient(object):
         return cls(url, token, debug=debug, timeout=_to_int(timeout), org=org, default_tags=default_tags,
                    enable_gzip=enable_gzip, verify_ssl=_to_bool(verify_ssl), ssl_ca_cert=ssl_ca_cert,
                    connection_pool_maxsize=_to_int(connection_pool_maxsize), auth_basic=_to_bool(auth_basic),
-                   profilers=profilers, proxy=proxy)
+                   profilers=profilers, proxy=proxy, **kwargs)
 
     @classmethod
-    def _from_env_properties(cls, debug=None, enable_gzip=False):
+    def _from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):
         url = os.getenv('INFLUXDB_V2_URL', "http://localhost:8086")
         token = os.getenv('INFLUXDB_V2_TOKEN', "my-token")
         timeout = os.getenv('INFLUXDB_V2_TIMEOUT', "10000")
@@ -196,7 +196,7 @@ class _BaseClient(object):
         return cls(url, token, debug=debug, timeout=_to_int(timeout), org=org, default_tags=default_tags,
                    enable_gzip=enable_gzip, verify_ssl=_to_bool(verify_ssl), ssl_ca_cert=ssl_ca_cert,
                    connection_pool_maxsize=_to_int(connection_pool_maxsize), auth_basic=_to_bool(auth_basic),
-                   profilers=profilers)
+                   profilers=profilers, **kwargs)
 
 
 # noinspection PyMethodMayBeStatic

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -77,9 +77,18 @@ class InfluxDBClient(_BaseClient):
         self.close()
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
+
+        :param config_file: Path to configuration file
+        :param debug: Enable verbose logging of http requests
+        :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
+                            supports the Gzip compression.
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
+        :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
+                                               except batching writes. As a default there is no one retry strategy.
 
         The supported formats:
             - https://docs.python.org/3/library/configparser.html
@@ -153,12 +162,21 @@ class InfluxDBClient(_BaseClient):
 
         """
         return super(InfluxDBClient, cls)._from_config_file(config_file=config_file, debug=debug,
-                                                            enable_gzip=enable_gzip)
+                                                            enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
-    def from_env_properties(cls, debug=None, enable_gzip=False):
+    def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via environment properties.
+
+        :param debug: Enable verbose logging of http requests
+        :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
+                            supports the Gzip compression.
+        :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
+        :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
+                                               except batching writes. As a default there is no one retry strategy.
 
         Supported environment properties:
             - INFLUXDB_V2_URL
@@ -172,7 +190,7 @@ class InfluxDBClient(_BaseClient):
             - INFLUXDB_V2_PROFILERS
             - INFLUXDB_V2_TAG
         """
-        return super(InfluxDBClient, cls)._from_env_properties(debug=debug, enable_gzip=enable_gzip)
+        return super(InfluxDBClient, cls)._from_env_properties(debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     def write_api(self, write_options=WriteOptions(), point_settings=PointSettings(), **kwargs) -> WriteApi:
         """

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -72,7 +72,7 @@ class InfluxDBClientAsync(_BaseClient):
 
         from .._async.api_client import ApiClientAsync
         self.api_client = ApiClientAsync(configuration=self.conf, header_name=self.auth_header_name,
-                                         header_value=self.auth_header_value, retries=self.retries, **kwargs)
+                                         header_value=self.auth_header_value, **kwargs)
 
     async def __aenter__(self) -> 'InfluxDBClientAsync':
         """
@@ -93,9 +93,18 @@ class InfluxDBClientAsync(_BaseClient):
             self.api_client = None
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
+
+        :param config_file: Path to configuration file
+        :param debug: Enable verbose logging of http requests
+        :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
+                            supports the Gzip compression.
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
+        :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
+                                               except batching writes. As a default there is no one retry strategy.
 
         The supported formats:
             - https://docs.python.org/3/library/configparser.html
@@ -169,12 +178,21 @@ class InfluxDBClientAsync(_BaseClient):
 
         """
         return super(InfluxDBClientAsync, cls)._from_config_file(config_file=config_file, debug=debug,
-                                                                 enable_gzip=enable_gzip)
+                                                                 enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
-    def from_env_properties(cls, debug=None, enable_gzip=False):
+    def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via environment properties.
+
+        :param debug: Enable verbose logging of http requests
+        :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
+                            supports the Gzip compression.
+        :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
+        :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
+                                               except batching writes. As a default there is no one retry strategy.
 
         Supported environment properties:
             - INFLUXDB_V2_URL
@@ -188,7 +206,7 @@ class InfluxDBClientAsync(_BaseClient):
             - INFLUXDB_V2_PROFILERS
             - INFLUXDB_V2_TAG
         """
-        return super(InfluxDBClientAsync, cls)._from_env_properties(debug=debug, enable_gzip=enable_gzip)
+        return super(InfluxDBClientAsync, cls)._from_env_properties(debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     async def ping(self) -> bool:
         """

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -12,6 +12,7 @@ import pytest
 from urllib3.exceptions import NewConnectionError, HTTPError
 
 from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.write.retry import WritesRetry
 from influxdb_client.client.write_api import WriteOptions, WriteType, SYNCHRONOUS
 from tests.base_test import BaseTest
 
@@ -94,6 +95,11 @@ class InfluxDBClientTest(unittest.TestCase):
 
         self.assertTrue(self.client.api_client.configuration.verify_ssl)
 
+    def test_init_from_file_kwargs(self):
+        retry = WritesRetry(total=1, retry_interval=2, exponential_base=3)
+        self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.ini', retries=retry)
+        self.assertEqual(self.client.retries, retry)
+
     def test_init_from_file_ssl(self):
         self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config-disabled-ssl.ini')
 
@@ -140,6 +146,11 @@ class InfluxDBClientTest(unittest.TestCase):
         self.client = InfluxDBClient.from_env_properties()
 
         self.assertEqual(29, self.client.api_client.configuration.connection_pool_maxsize)
+
+    def test_init_from_env_kwargs(self):
+        retry = WritesRetry(total=1, retry_interval=2, exponential_base=3)
+        self.client = InfluxDBClient.from_env_properties(retries=retry)
+        self.assertEqual(self.client.retries, retry)
 
     def _start_http_server(self):
         import http.server


### PR DESCRIPTION
Closes #506

## Proposed Changes

This PR makes it possible for users to configure the client in this way:

```python
InfluxDBClient.from_config_file(retries=WritesRetry(total=3, retry_interval=1, exponential_base=2))
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
