### PR TITLE
fix: exception propagation for asynchronous `QueryApi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#510](https://github.com/influxdata/influxdb-client-python/pull/510): Allow to use client's optional configs for initialization from file or environment properties
 
+### Bug Fixes
+1. [#512](https://github.com/influxdata/influxdb-client-python/pull/512): Exception propagation for asynchronous `QueryApi` [async/await]
+
 ## 1.33.0 [2022-09-29]
 
 ### Features

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -374,6 +374,15 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
 
         self.assertEqual(4, len(records))
 
+    @async_test
+    async def test_query_exception_propagation(self):
+        await self.client.close()
+        self.client = InfluxDBClientAsync(url="http://localhost:8086", token="wrong", org="my-org")
+
+        with pytest.raises(InfluxDBError) as e:
+            await self.client.query_api().query("buckets()", "my-org")
+        self.assertEqual("unauthorized access", e.value.message)
+
     async def _prepare_data(self, measurement: str):
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3)
         _point2 = Point(measurement).tag("location", "New York").field("temperature", 24.3)


### PR DESCRIPTION
Closes #511

## Proposed Changes

Fixed exception propagation for asynchronous `QueryApi`. Others async APIs works correctly.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
