### PR TITLE
chore(ci): migrate Scheduled workflow to Scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,8 +201,7 @@ workflows:
 
   nightly:
     when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-python
       - check-aws-lambda-layer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,9 @@ jobs:
 workflows:
   version: 2
   build:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - check-code-style
       - check-docstyle
@@ -197,13 +200,9 @@ workflows:
           python-image: "cimg/python:3.10"
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-python
       - check-aws-lambda-layer


### PR DESCRIPTION
## Proposed Changes

The **Scheduled Workflows** uses client for nightly builds but the scheduled workflows will be phased out by the end of 2022. The CircleCI's configuration has to be migrate to **Scheduled pipelines**.

- https://circleci.com/docs/workflows/#scheduling-a-workflow
- https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

Configured trigger:

![image](https://user-images.githubusercontent.com/455137/194823009-9e00daa4-71b3-4dbe-9e17-ca7a33739fff.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
