### PR TITLE
fix(async): parsing query response with two-bytes UTF-8 character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#512](https://github.com/influxdata/influxdb-client-python/pull/512): Exception propagation for asynchronous `QueryApi` [async/await]
+1. [#518](https://github.com/influxdata/influxdb-client-python/pull/518): Parsing query response with two-bytes UTF-8 character [async/await]
 
 ## 1.33.0 [2022-09-29]
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -384,6 +384,10 @@ You should use the 'record.row' to access your data instead of 'record.values' d
 class _StreamReaderToWithAsyncRead:
     def __init__(self, response):
         self.response = response
+        self.decoder = codecs.getincrementaldecoder(_UTF_8_encoding)()
 
     async def read(self, size: int) -> str:
-        return (await self.response.read(size)).decode(_UTF_8_encoding)
+        raw_bytes = (await self.response.read(size))
+        if not raw_bytes:
+            return self.decoder.decode(b'', final=True)
+        return self.decoder.decode(raw_bytes, final=False)


### PR DESCRIPTION
Closes #517

## Proposed Changes

This PR fixes parsing query response for the `async` client if the CSV looks like:

```csv
#group,false,false,false,false,true,true,true
#datatype,string,long,dateTime:RFC3339,string,string,string,string
#default,_result,,,,,,
,result,table,_time,_value,_field,_measurement,type
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
,,0,2022-10-13T12:28:31.181418542Z,ÂÂÂ,value,async,error
...

```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
