### PR TITLE
fix: duplicated debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 
 ### Features
 1. [#510](https://github.com/influxdata/influxdb-client-python/pull/510): Allow to use client's optional configs for initialization from file or environment properties
-2. [#509](https://github.com/influxdata/influxdb-client-python/pull/509): MTLS support for the InfluxDB Python client
+1. [#509](https://github.com/influxdata/influxdb-client-python/pull/509): MTLS support for the InfluxDB Python client
 
 ### Bug Fixes
 1. [#512](https://github.com/influxdata/influxdb-client-python/pull/512): Exception propagation for asynchronous `QueryApi` [async/await]
 1. [#518](https://github.com/influxdata/influxdb-client-python/pull/518): Parsing query response with two-bytes UTF-8 character [async/await]
+1. [#521](https://github.com/influxdata/influxdb-client-python/pull/521): Duplicated `debug` output
 
 ## 1.33.0 [2022-09-29]
 

--- a/influxdb_client/configuration.py
+++ b/influxdb_client/configuration.py
@@ -171,7 +171,10 @@ class Configuration(object, metaclass=TypeWithDefault):
             for name, logger in self.loggers.items():
                 logger.setLevel(logging.DEBUG)
                 if name == 'influxdb_client.client.http':
-                    logger.addHandler(logging.StreamHandler(sys.stdout))
+                    # makes sure to do not duplicate stdout handler
+                    if not any(map(lambda h: isinstance(h, logging.StreamHandler) and h.stream == sys.stdout,
+                                   logger.handlers)):
+                        logger.addHandler(logging.StreamHandler(sys.stdout))
             # we use 'influxdb_client.client.http' logger instead of this
             # httplib.HTTPConnection.debuglevel = 1
         else:

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -391,6 +391,20 @@ class InfluxDBClientTestMock(unittest.TestCase):
 
         self.assertIn("Authorization: ***", log_stream.getvalue())
 
+    def test_duplicate_debug_logging_handler(self):
+        logging.getLogger('influxdb_client.client.http').handlers.clear()
+        self.influxdb_client = InfluxDBClient("http://localhost", "my-token", debug=True)
+        self.influxdb_client = InfluxDBClient("http://localhost", "my-token", debug=True)
+        logger = logging.getLogger('influxdb_client.client.http')
+        self.assertEqual(1, len(logger.handlers))
+
+    def test_custom_debug_logging_handler(self):
+        logging.getLogger('influxdb_client.client.http').addHandler(logging.FileHandler('logs.log'))
+        self.influxdb_client = InfluxDBClient("http://localhost", "my-token", debug=True)
+        self.influxdb_client = InfluxDBClient("http://localhost", "my-token", debug=True)
+        logger = logging.getLogger('influxdb_client.client.http')
+        self.assertEqual(2, len(logger.handlers))
+
 
 class ServerWithSelfSingedSSL(http.server.SimpleHTTPRequestHandler):
     def _set_headers(self):


### PR DESCRIPTION
Closes #519

## Proposed Changes

The `logging.StreamHandler(sys.stdout)` should appended only once into `Logger`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
