### PR TITLE
chore: add supports for Python 3.11, fix build for Python 3.7.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ workflows:
           python-image: "cimg/python:3.10"
       - tests-python:
           name: test-3.11
-          python-image: "python:3.11"
+          python-image: "cimg/python:3.11"
 
   nightly:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,9 @@ workflows:
       - tests-python:
           name: test-3.10
           python-image: "cimg/python:3.10"
+      - tests-python:
+          name: test-3.11
+          python-image: "python:3.11"
 
   nightly:
     when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.35.0 [unreleased]
 
+### CI
+1. [#523](https://github.com/influxdata/influxdb-client-python/pull/523): Add Python 3.11 to CI builds
+
 ## 1.34.0 [2022-10-27]
 
 ### Breaking Changes
@@ -13,9 +16,6 @@
 1. [#512](https://github.com/influxdata/influxdb-client-python/pull/512): Exception propagation for asynchronous `QueryApi` [async/await]
 1. [#518](https://github.com/influxdata/influxdb-client-python/pull/518): Parsing query response with two-bytes UTF-8 character [async/await]
 1. [#521](https://github.com/influxdata/influxdb-client-python/pull/521): Duplicated `debug` output
-
-### CI
-1. [#523](https://github.com/influxdata/influxdb-client-python/pull/523): Add Python 3.11 to CI builds
 
 ## 1.33.0 [2022-09-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 1. [#518](https://github.com/influxdata/influxdb-client-python/pull/518): Parsing query response with two-bytes UTF-8 character [async/await]
 1. [#521](https://github.com/influxdata/influxdb-client-python/pull/521): Duplicated `debug` output
 
+### CI
+1. [#523](https://github.com/influxdata/influxdb-client-python/pull/523): Add Python 3.11 to CI builds
+
 ## 1.33.0 [2022-09-29]
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Database',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -420,15 +420,3 @@ class ServerWithSelfSingedSSL(http.server.SimpleHTTPRequestHandler):
                  commit="abcdefgh")).encode('utf-8')
         self._set_headers(response)
         self.wfile.write(response)
-
-
-    # def do_GET(self):
-    #     response = json.dumps(
-    #         dict(name="influxdb", message="ready for queries and writes", status="pass", checks=[], version="2.0.0",
-    #              commit="abcdefgh")).encode('utf-8')
-    #     self.send_response(http.HTTPStatus.OK)
-    #     self.send_header("Content-type", 'application/json')
-    #     self.send_header("Content-Length", f'{len(response)}')
-    #     self.send_header("Last-Modified", self.date_time_string())
-    #     self.end_headers()
-    #     self.wfile.write(response)

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -407,14 +407,28 @@ class InfluxDBClientTestMock(unittest.TestCase):
 
 
 class ServerWithSelfSingedSSL(http.server.SimpleHTTPRequestHandler):
-    def _set_headers(self):
-        self.send_response(200)
-        self.send_header('Content-type', 'application/json')
+    def _set_headers(self, response: bytes):
+        self.send_response(http.HTTPStatus.OK)
+        self.send_header("Content-type", 'application/json')
+        self.send_header("Content-Length", f'{len(response)}')
+        self.send_header("Last-Modified", self.date_time_string())
         self.end_headers()
 
     def do_GET(self):
-        self._set_headers()
         response = json.dumps(
             dict(name="influxdb", message="ready for queries and writes", status="pass", checks=[], version="2.0.0",
                  commit="abcdefgh")).encode('utf-8')
+        self._set_headers(response)
         self.wfile.write(response)
+
+
+    # def do_GET(self):
+    #     response = json.dumps(
+    #         dict(name="influxdb", message="ready for queries and writes", status="pass", checks=[], version="2.0.0",
+    #              commit="abcdefgh")).encode('utf-8')
+    #     self.send_response(http.HTTPStatus.OK)
+    #     self.send_header("Content-type", 'application/json')
+    #     self.send_header("Content-Length", f'{len(response)}')
+    #     self.send_header("Last-Modified", self.date_time_string())
+    #     self.end_headers()
+    #     self.wfile.write(response)


### PR DESCRIPTION
## Proposed Changes

1. Add Python `3.11` to CI and `setup.py`.
2. Fixed build for Python 3.7.15 - the newest `cimg/python:3.7` uses `Ubuntu 20.04.1` as a base image. This Ubuntu contains new version of `OpenSSL` which doesn't works with our dummy HTTP server.

![image](https://user-images.githubusercontent.com/455137/198989923-4fa1426d-2680-406d-a0f2-00485f31864d.png)


https://app.circleci.com/pipelines/github/influxdata/influxdb-client-python/2146/workflows/9624a90e-6cab-4289-9698-da317fc00e09/jobs/11860

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
