### PR TITLE
fix: HTTP request return type for Management API [async/await]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#526](https://github.com/influxdata/influxdb-client-python/pull/526): Creating client instance from static configuration
+1. [#531](https://github.com/influxdata/influxdb-client-python/pull/531): HTTP request return type for Management API [async/await]
 
 ### CI
 1. [#523](https://github.com/influxdata/influxdb-client-python/pull/523): Add Python 3.11 to CI builds

--- a/examples/asynchronous_management.py
+++ b/examples/asynchronous_management.py
@@ -10,7 +10,7 @@ async def main():
         organizations_service = OrganizationsService(api_client=client.api_client)
 
         # Find organization with name 'my-org'
-        organizations = await organizations_service.get_orgs(org='my-org')
+        organizations = await organizations_service.get_orgs_async(org='my-org')
         for organization in organizations.orgs:
             print(f'name: {organization.name}, id: {organization.id}')
 

--- a/influxdb_client/_async/api_client.py
+++ b/influxdb_client/_async/api_client.py
@@ -186,8 +186,8 @@ class ApiClientAsync(object):
             else:
                 return_data = None
 
-        if _return_http_data_only:
-            return (return_data)
+        if _return_http_data_only is not False:
+            return return_data
         else:
             return (return_data, response_data.status,
                     response_data.getheaders())

--- a/influxdb_client/_async/api_client.py
+++ b/influxdb_client/_async/api_client.py
@@ -654,7 +654,7 @@ class ApiClientAsync(object):
 
     async def _signin(self, resource_path: str):
         if _requires_create_user_session(self.configuration, self.cookie, resource_path):
-            http_info = await SigninService(self).post_signin_async()
+            http_info = await SigninService(self).post_signin_async(_return_http_data_only=False)
             self.cookie = http_info[2]['set-cookie']
 
     async def _signout(self):

--- a/influxdb_client/client/delete_api_async.py
+++ b/influxdb_client/client/delete_api_async.py
@@ -33,5 +33,5 @@ class DeleteApiAsync(_BaseDeleteApi):
         org_param = get_org_query_param(org=org, client=self._influxdb_client, required_id=False)
 
         response = await self._service.post_delete_async(delete_predicate_request=predicate_request, bucket=bucket,
-                                                         org=org_param)
+                                                         org=org_param, _return_http_data_only=False)
         return response[1] == 204

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -120,6 +120,6 @@ class WriteApiAsync(_BaseWriteApi):
         body = b'\n'.join(payloads[write_precision])
         response = await self._write_service.post_write_async(org=org, bucket=bucket, body=body,
                                                               precision=write_precision, async_req=False,
-                                                              content_encoding="identity",
+                                                              content_encoding="identity", _return_http_data_only=False,
                                                               content_type="text/plain; charset=utf-8")
         return response[1] == 204

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -8,7 +8,7 @@ from io import StringIO
 import pytest
 from aioresponses import aioresponses
 
-from influxdb_client import Point, WritePrecision, BucketsService
+from influxdb_client import Point, WritePrecision, BucketsService, OrganizationsService, Organizations
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 from influxdb_client.client.query_api import QueryOptions
@@ -329,7 +329,7 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         self.assertIn("my-bucket", results)
         # Bucket API
         buckets_service = BucketsService(api_client=self.client.api_client)
-        results = await buckets_service.get_buckets()
+        results = await buckets_service.get_buckets_async()
         self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))
 
     @async_test
@@ -401,6 +401,13 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
 
         data_frame = await self.client.query_api().query_data_frame("from()", "my-org")
         self.assertEqual(1000, len(data_frame))
+
+    @async_test
+    async def test_management_apis(self):
+        service = OrganizationsService(api_client=self.client.api_client)
+        results = await service.get_orgs_async()
+        self.assertIsInstance(results, Organizations)
+        self.assertIn("my-org", list(map(lambda org: org.name, results.orgs)))
 
     async def _prepare_data(self, measurement: str):
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3)


### PR DESCRIPTION
## Proposed Changes

This PR fixes the return type for `*_async(...)` methods in management API. The async management API returns required object not `tuple` with HTTP status and headers.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
