### PR TITLE
refactor: use `HTTResponse.headers` instead deprecated `HTTPResponse.getheaders()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug Fixes
 1. [#526](https://github.com/influxdata/influxdb-client-python/pull/526): Creating client instance from static configuration
 1. [#531](https://github.com/influxdata/influxdb-client-python/pull/531): HTTP request return type for Management API [async/await]
+1. [#534](https://github.com/influxdata/influxdb-client-python/pull/534): Use `HTTResponse.headers` to clear deprecation warning [urllib3]
 
 ### CI
 1. [#523](https://github.com/influxdata/influxdb-client-python/pull/523): Add Python 3.11 to CI builds

--- a/influxdb_client/_sync/rest.py
+++ b/influxdb_client/_sync/rest.py
@@ -43,7 +43,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Return a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Return a given response header."""


### PR DESCRIPTION
## Proposed Changes

Refactor code to not deprecated variant:

![image](https://user-images.githubusercontent.com/455137/203901663-44727c71-68f4-49fe-867a-b70e2abb3c97.png)

The deprecation warning also causes failure of CI build:

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/455137/203902032-cc1f5b67-7f49-4ead-baf7-3e538398139c.png">

https://app.circleci.com/pipelines/github/influxdata/influxdb-client-python/2199/workflows/e1db935d-5dfd-4944-9beb-d113c4108e8b/jobs/12253

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
