### PR TITLE
feat(query): query to csv skip empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.36.0 [unreleased]
 
+### Features
+1. [#536](https://github.com/influxdata/influxdb-client-python/pull/536): Query to `CSV` skip empty lines
+
 ## 1.35.0 [2022-12-01]
 
 ### Features

--- a/examples/query.py
+++ b/examples/query.py
@@ -95,8 +95,7 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org",
                                      dialect=Dialect(header=False, delimiter=",", comment_prefix="#", annotations=[],
                                                      date_time_format="RFC3339"))
     for csv_line in csv_result:
-        if not len(csv_line) == 0:
-            print(f'Temperature in {csv_line[9]} is {csv_line[6]}')
+        print(f'Temperature in {csv_line[9]} is {csv_line[6]}')
 
     print()
     print()

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -262,11 +262,14 @@ class CSVIterator(Iterator[List[str]]):
 
     def __iter__(self):
         """Return an iterator object."""
-        return self.delegate.__iter__()
+        return self
 
     def __next__(self):
         """Retrieve the next item from the iterator."""
-        return self.delegate.__next__()
+        row = self.delegate.__next__()
+        while not row:
+            row = self.delegate.__next__()
+        return row
 
     def to_values(self) -> List[List[str]]:
         """
@@ -284,4 +287,4 @@ class CSVIterator(Iterator[List[str]]):
                 ...
             ]
         """
-        return list(self.delegate)
+        return list(self.__iter__())

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -557,8 +557,8 @@ class SimpleQueryTest(BaseTest):
 
         self.client = InfluxDBClient("http://localhost", "my-token", org="my-org", enable_gzip=False)
 
-        csv_lines = self.client.query_api().query_csv('from(bucket: "my-bucket")', "my-org")
-        self.assertEqual(18, len(list(csv_lines)))
+        csv_lines = list(self.client.query_api().query_csv('from(bucket: "my-bucket")', "my-org"))
+        self.assertEqual(18, len(csv_lines))
         for csv_line in csv_lines:
             self.assertEqual(6, len(csv_line))
 

--- a/tests/test_QueryApi.py
+++ b/tests/test_QueryApi.py
@@ -530,6 +530,41 @@ class SimpleQueryTest(BaseTest):
             self.assertEqual('DateTimeLiteral', ast.body[0].assignment.init.type)
             self.assertEqual(literal[1], ast.body[0].assignment.init.value)
 
+    def test_csv_empty_lines(self):
+        query_response = '#datatype,string,long,dateTime:RFC3339,double,string\n' \
+                         '#group,false,false,false,false,true\n' \
+                         '#default,_result,,,,\n' \
+                         ',result,table,_time,_value,_field\n' \
+                         ',,0,2022-11-24T10:00:10Z,0.1,_1_current_(mA)\n' \
+                         ',,1,2022-11-24T10:00:10Z,4,_1_current_limit_(mA)\n' \
+                         ',,2,2022-11-24T10:00:10Z,1,_1_voltage_(V)\n' \
+                         ',,3,2022-11-24T10:00:10Z,1,_1_voltage_limit_(V)\n' \
+                         ',,4,2022-11-24T10:00:10Z,0,_2_current_(mA)\n' \
+                         ',,5,2022-11-24T10:00:10Z,0,_2_current_limit_(mA)\n' \
+                         ',,6,2022-11-24T10:00:10Z,0,_2_voltage_(V)\n' \
+                         ',,7,2022-11-24T10:00:10Z,0,_2_voltage_limit_(V)\n' \
+                         '\n' \
+                         '\n' \
+                         '#datatype,string,long,dateTime:RFC3339,string,string\n' \
+                         '#group,false,false,false,false,true\n' \
+                         '#default,_result,,,,\n' \
+                         ',result,table,_time,_value,_field\n' \
+                         ',,8,2022-11-24T10:00:10Z,K,type\n' \
+                         ',,9,2022-11-24T10:00:10Z,,type2\n' \
+                         '\n'
+
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/query", status=200, body=query_response)
+
+        self.client = InfluxDBClient("http://localhost", "my-token", org="my-org", enable_gzip=False)
+
+        csv_lines = self.client.query_api().query_csv('from(bucket: "my-bucket")', "my-org")
+        self.assertEqual(18, len(list(csv_lines)))
+        for csv_line in csv_lines:
+            self.assertEqual(6, len(csv_line))
+
+        # to_values
+        csv_lines = self.client.query_api().query_csv('from(bucket: "my-bucket")', "my-org").to_values()
+        self.assertEqual(18, len(csv_lines))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #533 

## Proposed Changes

The querying into CSV skip empty lines from InfluxDB response.

```csv
#datatype,string,long,dateTime:RFC3339,double,string
#group,false,false,false,false,true
#default,_result,,,,
,result,table,_time,_value,_field
,,0,2022-11-24T10:00:10Z,0.1,_1_current_(mA)
,,1,2022-11-24T10:00:10Z,4,_1_current_limit_(mA)
,,2,2022-11-24T10:00:10Z,1,_1_voltage_(V)
,,3,2022-11-24T10:00:10Z,1,_1_voltage_limit_(V)
,,4,2022-11-24T10:00:10Z,0,_2_current_(mA)
,,5,2022-11-24T10:00:10Z,0,_2_current_limit_(mA)
,,6,2022-11-24T10:00:10Z,0,_2_voltage_(V)
,,7,2022-11-24T10:00:10Z,0,_2_voltage_limit_(V)

#datatype,string,long,dateTime:RFC3339,string,string
#group,false,false,false,false,true
#default,_result,,,,
,result,table,_time,_value,_field
,,8,2022-11-24T10:00:10Z,K,type
,,9,2022-11-24T10:00:10Z,,type2

```

is parsed as:

```python
['#group', 'false', 'false', 'false', 'false', 'true']
['#default', '_result', '', '', '', '']
['', 'result', 'table', '_time', '_value', '_field']
['', '', '0', '2022-11-24T10:00:10Z', '0.1', '_1_current_(mA)']
['', '', '1', '2022-11-24T10:00:10Z', '4', '_1_current_limit_(mA)']
['', '', '2', '2022-11-24T10:00:10Z', '1', '_1_voltage_(V)']
['', '', '3', '2022-11-24T10:00:10Z', '1', '_1_voltage_limit_(V)']
['', '', '4', '2022-11-24T10:00:10Z', '0', '_2_current_(mA)']
['', '', '5', '2022-11-24T10:00:10Z', '0', '_2_current_limit_(mA)']
['', '', '6', '2022-11-24T10:00:10Z', '0', '_2_voltage_(V)']
['', '', '7', '2022-11-24T10:00:10Z', '0', '_2_voltage_limit_(V)']
['#datatype', 'string', 'long', 'dateTime:RFC3339', 'string', 'string']
['#group', 'false', 'false', 'false', 'false', 'true']
['#default', '_result', '', '', '', '']
['', 'result', 'table', '_time', '_value', '_field']
['', '', '8', '2022-11-24T10:00:10Z', 'K', 'type']
['', '', '9', '2022-11-24T10:00:10Z', '', 'type2']
```

not as:

```python
['#datatype', 'string', 'long', 'dateTime:RFC3339', 'double', 'string']
['#group', 'false', 'false', 'false', 'false', 'true']
['#default', '_result', '', '', '', '']
['', 'result', 'table', '_time', '_value', '_field']
['', '', '0', '2022-11-24T10:00:10Z', '0.1', '_1_current_(mA)']
['', '', '1', '2022-11-24T10:00:10Z', '4', '_1_current_limit_(mA)']
['', '', '2', '2022-11-24T10:00:10Z', '1', '_1_voltage_(V)']
['', '', '3', '2022-11-24T10:00:10Z', '1', '_1_voltage_limit_(V)']
['', '', '4', '2022-11-24T10:00:10Z', '0', '_2_current_(mA)']
['', '', '5', '2022-11-24T10:00:10Z', '0', '_2_current_limit_(mA)']
['', '', '6', '2022-11-24T10:00:10Z', '0', '_2_voltage_(V)']
['', '', '7', '2022-11-24T10:00:10Z', '0', '_2_voltage_limit_(V)']
[]
[]
['#datatype', 'string', 'long', 'dateTime:RFC3339', 'string', 'string']
['#group', 'false', 'false', 'false', 'false', 'true']
['#default', '_result', '', '', '', '']
['', 'result', 'table', '_time', '_value', '_field']
['', '', '8', '2022-11-24T10:00:10Z', 'K', 'type']
['', '', '9', '2022-11-24T10:00:10Z', '', 'type2']
[]
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
