### PR TITLE
feat: configure types of integers fields when initializing Point from `dict` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#536](https://github.com/influxdata/influxdb-client-python/pull/536): Query to `CSV` skip empty lines
+1. [#538](https://github.com/influxdata/influxdb-client-python/pull/538): Configure types of `integer` fields when initializing `Point` from `dict` structure
 
 ## 1.35.0 [2022-12-01]
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -482,6 +482,63 @@ class PointTest(unittest.TestCase):
                                 record_field_keys=["pressure", "temperature"])
         self.assertEqual("sensor_pt859,location=warehouse_125 pressure=125i", point.to_line_protocol())
 
+    def test_from_dictionary_uint(self):
+        dict_structure = {
+            "measurement": "h2o_feet",
+            "tags": {"location": "coyote_creek"},
+            "fields": {
+                "water_level": 1.0,
+                "some_counter": 108913123234
+            },
+            "time": 1
+        }
+        point = Point.from_dict(dict_structure, field_types={"some_counter": "uint"})
+        self.assertEqual("h2o_feet,location=coyote_creek some_counter=108913123234u,water_level=1 1",
+                         point.to_line_protocol())
+
+    def test_from_dictionary_int(self):
+        dict_structure = {
+            "measurement": "h2o_feet",
+            "tags": {"location": "coyote_creek"},
+            "fields": {
+                "water_level": 1.0,
+                "some_counter": 108913123234
+            },
+            "time": 1
+        }
+        point = Point.from_dict(dict_structure, field_types={"some_counter": "int"})
+        self.assertEqual("h2o_feet,location=coyote_creek some_counter=108913123234i,water_level=1 1",
+                         point.to_line_protocol())
+
+    def test_from_dictionary_float(self):
+        dict_structure = {
+            "measurement": "h2o_feet",
+            "tags": {"location": "coyote_creek"},
+            "fields": {
+                "water_level": 1.0,
+                "some_counter": 108913123234
+            },
+            "time": 1
+        }
+        point = Point.from_dict(dict_structure, field_types={"some_counter": "float"})
+        self.assertEqual("h2o_feet,location=coyote_creek some_counter=108913123234,water_level=1 1",
+                         point.to_line_protocol())
+
+    def test_from_dictionary_float_from_dict(self):
+        dict_structure = {
+            "measurement": "h2o_feet",
+            "tags": {"location": "coyote_creek"},
+            "fields": {
+                "water_level": 1.0,
+                "some_counter": 108913123234
+            },
+            "field_types": {"some_counter": "float"},
+            "time": 1
+        }
+        point = Point.from_dict(dict_structure)
+        self.assertEqual("h2o_feet,location=coyote_creek some_counter=108913123234,water_level=1 1",
+                         point.to_line_protocol())
+
     def test_static_measurement_name(self):
         dictionary = {
             "name": "sensor_pt859",


### PR DESCRIPTION
Closes #516

## Proposed Changes

The users can specify integer types by:

```python
# Use custom dictionary structure
dict_structure = {
    "measurement": "h2o_feet",
    "tags": {"location": "coyote_creek"},
    "fields": {
        "water_level": 1.0,
        "some_counter": 108913123234
    },
    "time": 1
}

point = Point.from_dict(dict_structure, field_types={"some_counter": "uint"})
```

**Documentation:**

![image](https://user-images.githubusercontent.com/455137/206666638-9ac46f8b-ef4a-4785-b0cb-b90961b4b373.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
