### PR TITLE
docs: clarify the unit of a parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -427,7 +427,7 @@ The batching is configurable by ``write_options``\ :
      - Description
      - Default Value
    * - **batch_size**
-     - the number of data pointx to collect in a batch
+     - the number of data point to collect in a batch
      - ``1000``
    * - **flush_interval**
      - the number of milliseconds before the batch is written

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -57,10 +57,11 @@ class WriteOptions(object):
 
         :param write_type: methods of write (batching, asynchronous, synchronous)
         :param batch_size: the number of data point to collect in batch
-        :param flush_interval: flush data at least in this interval
+        :param flush_interval: flush data at least in this interval (milliseconds)
         :param jitter_interval: this is primarily to avoid large write spikes for users running a large number of
-               client instances ie, a jitter of 5s and flush duration 10s means flushes will happen every 10-15s.
-        :param retry_interval: the time to wait before retry unsuccessful write
+               client instances ie, a jitter of 5s and flush duration 10s means flushes will happen every 10-15s
+               (milliseconds)
+        :param retry_interval: the time to wait before retry unsuccessful write (milliseconds)
         :param max_retries: the number of max retries when write fails, 0 means retry is disabled
         :param max_retry_delay: the maximum delay between each retry attempt in milliseconds
         :param max_retry_time: total timeout for all retry attempts in milliseconds, if 0 retry is disabled


### PR DESCRIPTION
## Proposed Changes

Clarify units for `flush_interval `, `jitter_interval` and `retry_interval `.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
