### PR TITLE
fix: numpy no longer supports `np.float` type

### DIFF
--- a/tests/test_WriteApiDataFrame.py
+++ b/tests/test_WriteApiDataFrame.py
@@ -327,7 +327,7 @@ class DataSerializerTest(unittest.TestCase):
         from influxdb_client.extras import pd, np
         now = pd.Timestamp('2020-04-05 00:00+00:00')
 
-        float_types = [np.float, np.float16, np.float32, np.float64]
+        float_types = [np.float16, np.float32, np.float64]
         if hasattr(np, 'float128'):
             float_types.append(np.float128)
         for np_float_type in float_types:

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -399,7 +399,6 @@ class PointTest(unittest.TestCase):
 
         point = Point.measurement("h2o") \
             .tag("location", "europe") \
-            .field("np.float1", np.float(1.123)) \
             .field("np.float2", np.float16(2.123)) \
             .field("np.float3", np.float32(3.123)) \
             .field("np.float4", np.float64(4.123)) \
@@ -413,7 +412,7 @@ class PointTest(unittest.TestCase):
             .field("np.uint4", np.uint64(8))
 
         self.assertEqual(
-            "h2o,location=europe np.float1=1.123,np.float2=2.123,np.float3=3.123,np.float4=4.123,np.int1=1i,np.int2=2i,np.int3=3i,np.int4=4i,np.uint1=5i,np.uint2=6i,np.uint3=7i,np.uint4=8i",
+            "h2o,location=europe np.float2=2.123,np.float3=3.123,np.float4=4.123,np.int1=1i,np.int2=2i,np.int3=3i,np.int4=4i,np.uint1=5i,np.uint2=6i,np.uint3=7i,np.uint4=8i",
             point.to_line_protocol())
 
     def test_from_dictionary_custom_measurement(self):


### PR DESCRIPTION
## Proposed Changes

The `numpy` no longer supports `np.float` type:

<img width="767" alt="image" src="https://user-images.githubusercontent.com/455137/208860442-91926bc8-6d37-415d-8d47-0cfffcb5584f.png">

For more info see - https://numpy.org/doc/stable/release/1.24.0-notes.html

This PR also fixes CI builds:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/455137/208861041-b1e98ce4-8c13-48ca-91ad-28d0c635dfeb.png">

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/455137/208861193-bc923ff8-2451-4d2a-8992-da730401b5c3.png">

https://app.circleci.com/pipelines/github/influxdata/influxdb-client-python?branch=clarify-config-measurements

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
