### PR TITLE
Add database creation/deletion for Influx 1.8

### DIFF
--- a/influxdb_client/client/bucket_api.py
+++ b/influxdb_client/client/bucket_api.py
@@ -58,6 +58,51 @@ class BucketsApi(object):
 
         return self._buckets_service.post_buckets(post_bucket_request=bucket)
 
+    def create_database(self, database=None, retention_rules=None):
+        """Create a database at the v1 api (legacy).
+        
+        :param database_name: name of the new database
+        :param retention_rules: retention rules array or single BucketRetentionRules
+        :return: Tuple (response body, status code, header dict)"""
+        if database is None:
+            raise ValueError("Invalid value for `database`, must be defined.")
+
+        if retention_rules is None:
+            retention_rules = []
+
+        rules = []
+
+        if isinstance(retention_rules, list):
+            rules.extend(retention_rules)
+        else:
+            rules.append(retention_rules)
+
+        # Hedaer and local_var_params for standard procedures only
+        header_params = {}
+        header_params['Accept'] = self._influxdb_client.api_client.select_header_accept(
+            ['application/json'])
+        header_params['Content-Type'] = self._influxdb_client.api_client.select_header_content_type(
+            ['application/json'])
+        local_var_params = locals()
+        local_var_params['kwargs'] = {}
+        all_params = []
+        self._buckets_service._check_operation_params(
+            "create_database", all_params, local_var_params
+        )
+
+        return self._influxdb_client.api_client.call_api(
+            '/query', 'POST',
+            header_params=header_params,
+            path_params={}, post_params=[],
+            files={}, auth_settings=[], collection_formats={},
+            query_params={'q': f'CREATE DATABASE {database}'},
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            urlopen_kw=None
+        )
+
     def update_bucket(self, bucket: Bucket) -> Bucket:
         """Update a bucket.
 
@@ -82,6 +127,41 @@ class BucketsApi(object):
             bucket_id = bucket
 
         return self._buckets_service.delete_buckets_id(bucket_id=bucket_id)
+
+    def delete_database(self, database=None):
+        """Delete a database at the v1 api (legacy).
+        
+        :param database_name: name of the database to delete
+        :param retention_rules: retention rules array or single BucketRetentionRules
+        :return: Tuple (response body, status code, header dict)"""
+        if database is None:
+            raise ValueError("Invalid value for `database`, must be defined.")
+
+        # Hedaer and local_var_params for standard procedures only
+        header_params = {}
+        header_params['Accept'] = self._influxdb_client.api_client.select_header_accept(
+            ['application/json'])
+        header_params['Content-Type'] = self._influxdb_client.api_client.select_header_content_type(
+            ['application/json'])
+        local_var_params = locals()
+        local_var_params['kwargs'] = {}
+        all_params = []
+        self._buckets_service._check_operation_params(
+            "drop_database", all_params, local_var_params
+        )
+
+        return self._influxdb_client.api_client.call_api(
+            '/query', 'POST',
+            header_params=header_params,
+            path_params={}, post_params=[],
+            files={}, auth_settings=[], collection_formats={},
+            query_params={'q': f'DROP DATABASE {database}'},
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            urlopen_kw=None
+        )
 
     def find_bucket_by_id(self, id):
         """Find bucket by ID.


### PR DESCRIPTION
Add features related to #541 and #259 

## Proposed Changes

In order to maintain a minimum of compatibility to Influx v1.8 the creation an deletion of buckets (old: databases) should be supported. With these little enhancements the influxdb-client-python could easily.

I implemented two new methods for calls to v1 API if the method for creating or deleting a bucket fails with an `ApiException`. That way no code changes are necessary regardless which version of Influx you are running on.

I implemented this with a call to the method `influxdb_client.api_client.call_api` instead of using the `_buckets_service.post_buckets` as this was easier and with less code changes. I had to invoke the creation of some arguments and hope you find it clean enough.

## Checklist

As I just changed functionallity which wasn't there before and doesn't effect any of the other methods I don't know what to test or how to write a test for this. If this or anything else is needed, please advice me to the right direction.