### PR TITLE
fix(data_frame): parsing empty query result value as `numpy.NaN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-This release disables using of the HTTP proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` for the asynchronous HTTP client. 
+This release disables using of the HTTP proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` for the asynchronous HTTP client.
 The proxy environment variables must be explicitly enabled in the client's configuration:
 
 ```python
@@ -15,6 +15,7 @@ async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", or
 
 ### Bug Fixes
 1. [#583](https://github.com/influxdata/influxdb-client-python/pull/583): Async HTTP client doesn't always use `HTTP_PROXY`/`HTTPS_PROXY` environment variables. [async/await]
+1. [#584](https://github.com/influxdata/influxdb-client-python/pull/584): Parsing empty query result value as `numpy.NaN`
 
 ## 1.36.1 [2023-02-23]
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -268,10 +268,12 @@ class FluxCsvParser(object):
         return record
 
     def _to_value(self, str_val, column):
-
         if str_val == '' or str_val is None:
             default_value = column.default_value
             if default_value == '' or default_value is None:
+                if self._serialization_mode is FluxSerializationMode.dataFrame:
+                    from ..extras import np
+                    return self._to_value(np.nan, column)
                 return None
             return self._to_value(default_value, column)
 

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -268,6 +268,7 @@ class FluxCsvParser(object):
         return record
 
     def _to_value(self, str_val, column):
+
         if str_val == '' or str_val is None:
             default_value = column.default_value
             if default_value == '' or default_value is None:

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -267,15 +267,14 @@ class FluxCsvParserTest(unittest.TestCase):
         data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,boolean\n" \
                "#group,false,false,true,true,true,true,true,true,false\n" \
                "#default,_result,,,,,,,,\n" \
-               ",result,table,_start,_stop,_field,_measurement,host,region,value4\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
                ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,true\n" \
                ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
 
         parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
                              response_metadata_mode=FluxResponseMetadataMode.full)
         df = list(parser.generator())[0]
-        print(df.to_string())
-        self.assertEqual('bool', df.dtypes['value4'].name)
+        self.assertEqual('bool', df.dtypes['value'].name)
 
     def test_parse_without_datatype(self):
         data = ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n" \

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -263,6 +263,20 @@ class FluxCsvParserTest(unittest.TestCase):
         self.assertEqual('bool', df.dtypes['value4'].name)
         self.assertEqual('float64', df.dtypes['value5'].name)
 
+    def test_pandas_null_bool_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,boolean\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value4\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,true\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full)
+        df = list(parser.generator())[0]
+        print(df.to_string())
+        self.assertEqual('bool', df.dtypes['value4'].name)
+
     def test_parse_without_datatype(self):
         data = ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n" \
                ",,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test\n" \


### PR DESCRIPTION
Closes #550

## Proposed Changes

The empty values in query results from serialization into Pandas DataFrame are returned as `numpy.NaN` values instead of `''` - empty string.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
