### PR TITLE
feat: possibility to precise which config name to load when loading config from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", or
                                client_session_kwargs={'trust_env': True}) as client:
     pass
 ```
+### Features
+1. [#586](https://github.com/influxdata/influxdb-client-python/pull/586): Add `config_name` argument for ``from_config_file`` function to allow loading a specific configuration from a config file
 
 ### Bug Fixes
 1. [#583](https://github.com/influxdata/influxdb-client-python/pull/583): Async HTTP client doesn't always use `HTTP_PROXY`/`HTTPS_PROXY` environment variables. [async/await]
@@ -192,8 +194,6 @@ This release introduces a support for new version of InfluxDB OSS API definition
 
 ### Features
 1. [#393](https://github.com/influxdata/influxdb-client-python/pull/393): Add callback function for getting profilers output with example and test
-2. [#586](https://github.com/influxdata/influxdb-client-python/pull/586): Add `config_name` argument for
-    ``from_config_file`` function to allow loading a specific configuration from a config file
 
 ### Bug Fixes
 1. [#375](https://github.com/influxdata/influxdb-client-python/pull/375): Construct `InfluxDBError` without HTTP response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,8 @@ This release introduces a support for new version of InfluxDB OSS API definition
 
 ### Features
 1. [#393](https://github.com/influxdata/influxdb-client-python/pull/393): Add callback function for getting profilers output with example and test
+2. [#586](https://github.com/influxdata/influxdb-client-python/pull/586): Add `config_name` argument for
+    ``from_config_file`` function to allow loading a specific configuration from a config file
 
 ### Bug Fixes
 1. [#375](https://github.com/influxdata/influxdb-client-python/pull/375): Construct `InfluxDBError` without HTTP response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", or
     pass
 ```
 ### Features
-1. [#586](https://github.com/influxdata/influxdb-client-python/pull/586): Add `config_name` argument for ``from_config_file`` function to allow loading a specific configuration from a config file
+1. [#586](https://github.com/influxdata/influxdb-client-python/pull/586): Add `config_name` key argument for ``from_config_file`` function to allow loading a specific configuration from a config file
 
 ### Bug Fixes
 1. [#583](https://github.com/influxdata/influxdb-client-python/pull/583): Async HTTP client doesn't always use `HTTP_PROXY`/`HTTPS_PROXY` environment variables. [async/await]

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -100,7 +100,6 @@ class _BaseClient(object):
 
     @classmethod
     def _from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
-
         config = configparser.ConfigParser()
         config_name = kwargs.get('config_name', 'influx2')
         is_json = False

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -99,8 +99,9 @@ class _BaseClient(object):
         pass
 
     @classmethod
-    def _from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
-                          debug=None, enable_gzip=False, **kwargs):
+    def _from_config_file(cls, config_file: str = "config.ini", debug=None,
+                          config_name: str = "influx2", enable_gzip=False, **kwargs):
+
         config = configparser.ConfigParser()
         is_json = False
         try:

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -100,9 +100,10 @@ class _BaseClient(object):
 
     @classmethod
     def _from_config_file(cls, config_file: str = "config.ini", debug=None,
-                          config_name: str = "influx2", enable_gzip=False, **kwargs):
+                          enable_gzip=False, **kwargs):
 
         config = configparser.ConfigParser()
+        config_name = kwargs.get('config_name', 'influx2')
         is_json = False
         try:
             config.read(config_file)

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -99,8 +99,7 @@ class _BaseClient(object):
         pass
 
     @classmethod
-    def _from_config_file(cls, config_file: str = "config.ini", debug=None,
-                          enable_gzip=False, **kwargs):
+    def _from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
 
         config = configparser.ConfigParser()
         config_name = kwargs.get('config_name', 'influx2')

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -99,7 +99,8 @@ class _BaseClient(object):
         pass
 
     @classmethod
-    def _from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
+    def _from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
+                          debug=None, enable_gzip=False, **kwargs):
         config = configparser.ConfigParser()
         is_json = False
         try:

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -99,7 +99,7 @@ class _BaseClient(object):
         pass
 
     @classmethod
-    def _from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
+    def _from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
         config = configparser.ConfigParser()
         is_json = False
         try:
@@ -111,11 +111,11 @@ class _BaseClient(object):
                 is_json = True
 
         def _config_value(key: str):
-            value = str(config[key]) if is_json else config['influx2'][key]
+            value = str(config[key]) if is_json else config[config_name][key]
             return value.strip('"')
 
         def _has_option(key: str):
-            return key in config if is_json else config.has_option('influx2', key)
+            return key in config if is_json else config.has_option(config_name, key)
 
         def _has_section(key: str):
             return key in config if is_json else config.has_section(key)

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -83,8 +83,8 @@ class InfluxDBClient(_BaseClient):
         self.close()
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
-                         debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False,
+                         config_name: str = "influx2", **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -83,8 +83,7 @@ class InfluxDBClient(_BaseClient):
         self.close()
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False,
-                         config_name: str = "influx2", **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 
@@ -92,7 +91,7 @@ class InfluxDBClient(_BaseClient):
         :param debug: Enable verbose logging of http requests
         :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
-        :param config_name: Name of the configuration section of the configuration file
+        :key config_name: Name of the configuration section of the configuration file
         :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
                                 authentication.
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
@@ -175,8 +174,7 @@ class InfluxDBClient(_BaseClient):
             }
 
         """
-        return InfluxDBClient._from_config_file(config_file=config_file, config_name=config_name,
-                                                debug=debug, enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClient._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -149,7 +149,7 @@ class InfluxDBClient(_BaseClient):
                 profilers="query, operator"
                 proxy = "http://proxy.domain.org:8080"
 
-            [tags]config_name
+            [tags]
                 id = "132-987-655"
                 customer = "California Miner"
                 data_center = "${env.data_center}"

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -83,7 +83,8 @@ class InfluxDBClient(_BaseClient):
         self.close()
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
+                         debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -83,7 +83,7 @@ class InfluxDBClient(_BaseClient):
         self.close()
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 
@@ -149,7 +149,7 @@ class InfluxDBClient(_BaseClient):
                 profilers="query, operator"
                 proxy = "http://proxy.domain.org:8080"
 
-            [tags]
+            [tags]config_name
                 id = "132-987-655"
                 customer = "California Miner"
                 data_center = "${env.data_center}"
@@ -173,7 +173,8 @@ class InfluxDBClient(_BaseClient):
             }
 
         """
-        return InfluxDBClient._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClient._from_config_file(config_file=config_file, config_name=config_name,
+                                                debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -92,6 +92,7 @@ class InfluxDBClient(_BaseClient):
         :param debug: Enable verbose logging of http requests
         :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
+        :param config_name: Name of the configuration section of the configuration file
         :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
                                 authentication.
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -108,6 +108,7 @@ class InfluxDBClientAsync(_BaseClient):
         :param debug: Enable verbose logging of http requests
         :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
+        :param config_name: Name of the configuration section of the configuration file
         :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
                                 authentication.
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -99,7 +99,7 @@ class InfluxDBClientAsync(_BaseClient):
             self.api_client = None
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 
@@ -189,8 +189,8 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug,
-                                                     enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, config_name=config_name,
+                                                     debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -190,7 +190,8 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, 
+                                                     enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -190,7 +190,7 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, 
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug,
                                                      enable_gzip=enable_gzip, **kwargs)
 
     @classmethod

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -190,7 +190,8 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip,
+                                                     **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -99,8 +99,8 @@ class InfluxDBClientAsync(_BaseClient):
             self.api_client = None
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
-                         debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False,
+                         config_name: str = "influx2", **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -190,8 +190,7 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip,
-                                                     **kwargs)
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -99,7 +99,8 @@ class InfluxDBClientAsync(_BaseClient):
             self.api_client = None
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2", debug=None, enable_gzip=False, **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", config_name: str = "influx2",
+                         debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -99,8 +99,7 @@ class InfluxDBClientAsync(_BaseClient):
             self.api_client = None
 
     @classmethod
-    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False,
-                         config_name: str = "influx2", **kwargs):
+    def from_config_file(cls, config_file: str = "config.ini", debug=None, enable_gzip=False, **kwargs):
         """
         Configure client via configuration file. The configuration has to be under 'influx' section.
 
@@ -108,7 +107,7 @@ class InfluxDBClientAsync(_BaseClient):
         :param debug: Enable verbose logging of http requests
         :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
-        :param config_name: Name of the configuration section of the configuration file
+        :key config_name: Name of the configuration section of the configuration file
         :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
                                 authentication.
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
@@ -191,8 +190,7 @@ class InfluxDBClientAsync(_BaseClient):
             }
 
         """
-        return InfluxDBClientAsync._from_config_file(config_file=config_file, config_name=config_name,
-                                                     debug=debug, enable_gzip=enable_gzip, **kwargs)
+        return InfluxDBClientAsync._from_config_file(config_file=config_file, debug=debug, enable_gzip=enable_gzip, **kwargs)
 
     @classmethod
     def from_env_properties(cls, debug=None, enable_gzip=False, **kwargs):

--- a/tests/config2.ini
+++ b/tests/config2.ini
@@ -1,0 +1,13 @@
+[test_name]
+url=http://localhost:8086
+org=my-org
+token=my-token
+timeout=6000
+connection_pool_maxsize=55
+auth_basic=false
+profilers=query, operator
+
+[tags]
+id = 132-987-655
+customer = California Miner
+data_center = ${env.data_center}

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -75,6 +75,12 @@ class InfluxDBClientTest(unittest.TestCase):
 
         self.assertConfig()
 
+    def test_init_from_ini_file_custom_name(self):
+        self.client = InfluxDBClient.from_config_file(
+            f'{os.path.dirname(__file__)}/config2.ini', config_name='test_name')
+
+        self.assertConfig()
+
     def test_init_from_toml_file(self):
         self.client = InfluxDBClient.from_config_file(f'{os.path.dirname(__file__)}/config.toml')
 


### PR DESCRIPTION
Closes #585

## Proposed Changes

Possibility to precise which config name we want when loading from_config_file

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
