### PR TITLE
fix: Remove Content-Encoding=Identity as the header as it violates the RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 1.37.0 [unreleased]
 
-1. The `Config-Encoding: identity` header will no longer be set by the `write_api` calls to a remote server
-
 ### Breaking Changes
 
 This release disables using of the HTTP proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` for the asynchronous HTTP client.
@@ -31,6 +29,7 @@ This release introduces a support for new version of InfluxDB API definitions wi
 ### Bug Fixes
 1. [#583](https://github.com/influxdata/influxdb-client-python/pull/583): Async HTTP client doesn't always use `HTTP_PROXY`/`HTTPS_PROXY` environment variables. [async/await]
 1. [#584](https://github.com/influxdata/influxdb-client-python/pull/584): Parsing empty query result value as `numpy.NaN`
+1. [#595](https://github.com/influxdata/influxdb-client-python/pull/595): The `Config-Encoding: identity` header will no longer be set by the `write_api` calls to a remote server
 
 ## 1.36.1 [2023-02-23]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.37.0 [unreleased]
 
-1. The `Config-Encoding: identity` header will not be set by the `write` calls to the remote endpoints
+1. The `Config-Encoding: identity` header will no longer be set by the `write_api` calls to a remote server
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.37.0 [unreleased]
 
+1. The `Config-Encoding: identity` header will not be set by the `write` calls to the remote endpoints
+
 ### Breaking Changes
 
 This release disables using of the HTTP proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` for the asynchronous HTTP client.

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -507,7 +507,7 @@ You can use native asynchronous version of the client:
     def _post_write(self, _async_req, bucket, org, body, precision, **kwargs):
 
         return self._write_service.post_write(org=org, bucket=bucket, body=body, precision=precision,
-                                              async_req=_async_req, content_encoding="identity",
+                                              async_req=_async_req,
                                               content_type="text/plain; charset=utf-8",
                                               **kwargs)
 

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -120,6 +120,6 @@ class WriteApiAsync(_BaseWriteApi):
         body = b'\n'.join(payloads[write_precision])
         response = await self._write_service.post_write_async(org=org, bucket=bucket, body=body,
                                                               precision=write_precision, async_req=False,
-                                                              content_encoding="identity", _return_http_data_only=False,
+                                                              _return_http_data_only=False,
                                                               content_type="text/plain; charset=utf-8")
         return response[1] == 204

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -60,7 +60,6 @@ class GzipSupportTest(BaseTest):
         self.assertEqual("identity", _requests[0].headers['Accept-Encoding'])
         # Write
         self.assertEqual("/api/v2/write?org=my-org&bucket=my-bucket&precision=ns", _requests[1].path)
-        self.assertEqual("identity", _requests[1].headers['Content-Encoding'])
         self.assertEqual("identity", _requests[1].headers['Accept-Encoding'])
         self.assertEqual("h2o_feet,location=coyote_creek water_level=1 1", _requests[1].parsed_body)
         # Query


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-collector/issues/8114

## Proposed Changes

`Content-Encoding: identity` is incorrect and must not be set. As a result, the client is failing to write metrics to the OpenTelemetry Collector v0.81.0
RFC snippet: https://github.com/open-telemetry/opentelemetry-collector/issues/8114#issuecomment-1643494516

This change removes the hardcoded `Content-Encoding: identity` so that the remote servers don't reject the request. The go library of influx-client also does not add this header.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)

