### PR TITLE
refactor: use HTTResponse.headers instead deprecated `HTTPResponse.ge…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.38.0 [unreleased]
 
+### Bug Fixes
+1. [#601](https://github.com/influxdata/influxdb-client-python/pull/601): Use HTTResponse.headers to clear deprecation warning [urllib3]
+
 ### Documentation
 1. [#566](https://github.com/influxdata/influxdb-client-python/pull/566): Fix Sphinx documentation build and add support `.readthedocs.yml` V2 configuration file
 

--- a/influxdb_client/_sync/rest.py
+++ b/influxdb_client/_sync/rest.py
@@ -47,7 +47,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Return a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
…theader()`

## Proposed Changes

Similar to #534.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
