### PR TITLE
fix: return `str` instead of `urllib3.HTTPResponse` for `InfluxDBClie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,32 @@
 ## 1.39.0 [unreleased]
 
+### Breaking Changes
+
+1. [#569](https://github.com/influxdata/influxdb-client-python/pull/569): Return `str` instead of `urllib3.HTTPResponse` for `InfluxDBClient.QueryAPI.query_raw`.
+
+This fixes `InfluxDBClient.query_raw` that returned the wrong type based on the documentation.
+
+The async version `InfluxDBClientAsync` is not affected.
+
+To make your code compatible with this version, you can remove the step of retrieving the response content:
+
+```diff
+from influxdb_client.client import InfluxDBClient
+
+with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org") as client:
+    query = "..."
+    result = client.query_raw(query=query)
+-   content = result.data.decode("utf8")
++   content = result
+```
+
+
 ## 1.38.0 [2023-10-02]
 
 ### Bug Fixes
 1. [#601](https://github.com/influxdata/influxdb-client-python/pull/601): Use HTTResponse.headers to clear deprecation warning [urllib3]
 1. [#610](https://github.com/influxdata/influxdb-client-python/pull/601): Use iloc to clear deprecation warning
+
 
 ### Documentation
 1. [#566](https://github.com/influxdata/influxdb-client-python/pull/566): Fix Sphinx documentation build and add support `.readthedocs.yml` V2 configuration file

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -9,6 +9,7 @@ from typing import List, Generator, Any, Callable
 from influxdb_client import Dialect
 from influxdb_client.client._base import _BaseQueryApi
 from influxdb_client.client.flux_table import FluxRecord, TableList, CSVIterator
+from influxdb_client.rest import _UTF_8_encoding
 
 
 class QueryOptions(object):
@@ -121,8 +122,8 @@ class QueryApi(_BaseQueryApi):
         org = self._org_param(org)
         result = self._query_api.post_query(org=org, query=self._create_query(query, dialect, params), async_req=False,
                                             _preload_content=False)
-
-        return result
+        raw_bytes = result.data
+        return raw_bytes.decode(_UTF_8_encoding)
 
     def query(self, query: str, org=None, params: dict = None) -> TableList:
         """Execute synchronous Flux query and return result as a :class:`~influxdb_client.client.flux_table.FluxTable` list.

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -1,4 +1,3 @@
-import codecs
 import http.server
 import json
 import logging
@@ -346,7 +345,8 @@ class InfluxDBClientTestIT(BaseTest):
         self.assertIn("my-bucket", list(map(lambda record: record["name"], results[0].records)))
         # Query RAW
         results = self.client.query_api().query_raw("buckets()", "my-org")
-        self.assertIn("my-bucket", codecs.decode(results.data))
+        self.assertIn("my-bucket", results)
+        self.assertTrue(isinstance(results, str))
         # Bucket API
         results = self.client.buckets_api().find_buckets()
         self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))


### PR DESCRIPTION
Closes #569

## Proposed Changes

As it is done in the Async version of the client, return `str` response data as per the documentation.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
