### PR TITLE
fix: logging http requests without query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#562](https://github.com/influxdata/influxdb-client-python/pull/562): Use `ThreadPoolScheduler` for `WriteApi`'s batch subject instead of `TimeoutScheduler` to prevent creating unnecessary threads repeatedly
+1. [#631](https://github.com/influxdata/influxdb-client-python/pull/631): Logging HTTP requests without query parameters
 
 ## 1.39.0 [2023-12-05]
 

--- a/influxdb_client/_sync/rest.py
+++ b/influxdb_client/_sync/rest.py
@@ -170,7 +170,7 @@ class RESTClientObject(object):
             headers['Content-Type'] = 'application/json'
 
         if self.configuration.debug:
-            _BaseRESTClient.log_request(method, f"{url}?{urlencode(query_params)}")
+            _BaseRESTClient.log_request(method, f"{url}{'' if query_params is None else '?' + urlencode(query_params)}")
             _BaseRESTClient.log_headers(headers, '>>>')
             _BaseRESTClient.log_body(body, '>>>')
 

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -415,6 +415,18 @@ class InfluxDBClientTestMock(unittest.TestCase):
         logger = logging.getLogger('influxdb_client.client.http')
         self.assertEqual(2, len(logger.handlers))
 
+    def test_debug_request_without_query_parameters(self):
+        httpretty.register_uri(httpretty.GET, uri="http://localhost/ping", status=200, body="")
+        self.influxdb_client = InfluxDBClient("http://localhost", "my-token", debug=True)
+
+        log_stream = StringIO()
+        logger = logging.getLogger("influxdb_client.client.http")
+        logger.addHandler(logging.StreamHandler(log_stream))
+
+        self.influxdb_client.api_client.call_api('/ping', 'GET')
+
+        self.assertIn("'GET http://localhost/ping'", log_stream.getvalue())
+
 
 class ServerWithSelfSingedSSL(http.server.SimpleHTTPRequestHandler):
     def _set_headers(self, response: bytes):


### PR DESCRIPTION
Closes #630

## Proposed Changes

Fixed logging HTTP requests without query parameters.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
