### PR TITLE
fix: handle null values in data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.41.0 [unreleased]
 
+### Bug Fixes
+1. [#636](https://github.com/influxdata/influxdb-client-python/pull/636): Handle missing data in data frames
+
 ## 1.40.0 [2024-01-30]
 
 ### Features

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -277,23 +277,27 @@ class _BaseQueryApi(object):
         return (await _parser.__aenter__()).generator_async()
 
     def _to_data_frame_stream(self, data_frame_index, response, query_options=None,
-                              response_metadata_mode: FluxResponseMetadataMode = FluxResponseMetadataMode.full):
+                              response_metadata_mode: FluxResponseMetadataMode = FluxResponseMetadataMode.full,
+                              use_extension_dtypes=False):
         """
         Parse HTTP response to DataFrame stream.
 
         :param response: HTTP response from an HTTP client. Expected type: `urllib3.response.HTTPResponse`.
         """
-        _parser = self._to_data_frame_stream_parser(data_frame_index, query_options, response, response_metadata_mode)
+        _parser = self._to_data_frame_stream_parser(data_frame_index, query_options, response, response_metadata_mode,
+                                                    use_extension_dtypes)
         return _parser.generator()
 
     async def _to_data_frame_stream_async(self, data_frame_index, response, query_options=None, response_metadata_mode:
-                                          FluxResponseMetadataMode = FluxResponseMetadataMode.full):
+                                          FluxResponseMetadataMode = FluxResponseMetadataMode.full,
+                                          use_extension_dtypes=False):
         """
         Parse HTTP response to DataFrame stream.
 
         :param response: HTTP response from an HTTP client. Expected type: `aiohttp.client_reqrep.ClientResponse`.
         """
-        _parser = self._to_data_frame_stream_parser(data_frame_index, query_options, response, response_metadata_mode)
+        _parser = self._to_data_frame_stream_parser(data_frame_index, query_options, response, response_metadata_mode,
+                                                    use_extension_dtypes)
         return (await _parser.__aenter__()).generator_async()
 
     def _to_tables_parser(self, response, query_options, response_metadata_mode):
@@ -304,10 +308,12 @@ class _BaseQueryApi(object):
         return FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.stream,
                              query_options=query_options, response_metadata_mode=response_metadata_mode)
 
-    def _to_data_frame_stream_parser(self, data_frame_index, query_options, response, response_metadata_mode):
+    def _to_data_frame_stream_parser(self, data_frame_index, query_options, response, response_metadata_mode,
+                                     use_extension_dtypes):
         return FluxCsvParser(response=response, serialization_mode=FluxSerializationMode.dataFrame,
                              data_frame_index=data_frame_index, query_options=query_options,
-                             response_metadata_mode=response_metadata_mode)
+                             response_metadata_mode=response_metadata_mode,
+                             use_extension_dtypes=use_extension_dtypes)
 
     def _to_data_frames(self, _generator):
         """Parse stream of DataFrames into expected type."""

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -131,8 +131,6 @@ class FluxCsvParser(object):
         # Return latest DataFrame
         if (self._serialization_mode is FluxSerializationMode.dataFrame) & hasattr(self, '_data_frame'):
             df = self._prepare_data_frame()
-            if self._use_extension_dtypes:
-                df = df.convert_dtypes()
             if not self._is_profiler_table(metadata.table):
                 yield df
 
@@ -147,8 +145,6 @@ class FluxCsvParser(object):
             # Return latest DataFrame
             if (self._serialization_mode is FluxSerializationMode.dataFrame) & hasattr(self, '_data_frame'):
                 df = self._prepare_data_frame()
-                if self._use_extension_dtypes:
-                    df = df.convert_dtypes()
                 if not self._is_profiler_table(metadata.table):
                     yield df
         finally:
@@ -177,8 +173,6 @@ class FluxCsvParser(object):
                 # Return already parsed DataFrame
                 if (self._serialization_mode is FluxSerializationMode.dataFrame) & hasattr(self, '_data_frame'):
                     df = self._prepare_data_frame()
-                    if self._use_extension_dtypes:
-                        df = df.convert_dtypes()
                     if not self._is_profiler_table(metadata.table):
                         yield df
 
@@ -261,7 +255,11 @@ class FluxCsvParser(object):
             _temp_df = _temp_df.set_index(self._data_frame_index)
 
         # Append data
-        return pd.concat([self._data_frame.astype(_temp_df.dtypes), _temp_df])
+        df = pd.concat([self._data_frame.astype(_temp_df.dtypes), _temp_df])
+
+        if self._use_extension_dtypes:
+            return df.convert_dtypes()
+        return df
 
     def parse_record(self, table_index, table, csv):
         """Parse one record."""

--- a/influxdb_client/client/query_api.py
+++ b/influxdb_client/client/query_api.py
@@ -222,7 +222,8 @@ class QueryApi(_BaseQueryApi):
                                               async_req=False, _preload_content=False, _return_http_data_only=False)
         return self._to_flux_record_stream(response, query_options=self._get_query_options())
 
-    def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
+    def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None,
+                         use_extension_dtypes: bool = False):
         """
         Execute synchronous Flux query and return Pandas DataFrame.
 
@@ -234,6 +235,11 @@ class QueryApi(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
+        :param use_extension_dtypes: set to ``True`` to use panda's extension data types.
+                                     Useful for queries with ``pivot`` function.
+                                     When data has missing values, column data type may change (to ``object`` or ``float64``).
+                                     Nullable extension types (``Int64``, ``Float64``, ``boolean``) support ``panda.NA`` value.
+                                     For more info, see https://pandas.pydata.org/docs/user_guide/missing_data.html.
         :return: :class:`~DataFrame` or :class:`~List[DataFrame]`
 
         .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
@@ -250,10 +256,12 @@ class QueryApi(_BaseQueryApi):
                 - https://docs.influxdata.com/flux/latest/stdlib/universe/pivot/
                 - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
         """  # noqa: E501
-        _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index, params=params)
+        _generator = self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index, params=params,
+                                                  use_extension_dtypes=use_extension_dtypes)
         return self._to_data_frames(_generator)
 
-    def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
+    def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None,
+                                use_extension_dtypes: bool = False):
         """
         Execute synchronous Flux query and return stream of Pandas DataFrame as a :class:`~Generator[DataFrame]`.
 
@@ -265,6 +273,11 @@ class QueryApi(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClient.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
+        :param use_extension_dtypes: set to ``True`` to use panda's extension data types.
+                                     Useful for queries with ``pivot`` function.
+                                     When data has missing values, column data type may change (to ``object`` or ``float64``).
+                                     Nullable extension types (``Int64``, ``Float64``, ``boolean``) support ``panda.NA`` value.
+                                     For more info, see https://pandas.pydata.org/docs/user_guide/missing_data.html.
         :return: :class:`~Generator[DataFrame]`
 
         .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
@@ -289,7 +302,8 @@ class QueryApi(_BaseQueryApi):
 
         return self._to_data_frame_stream(data_frame_index=data_frame_index,
                                           response=response,
-                                          query_options=self._get_query_options())
+                                          query_options=self._get_query_options(),
+                                          use_extension_dtypes=use_extension_dtypes)
 
     def __del__(self):
         """Close QueryAPI."""

--- a/influxdb_client/client/query_api_async.py
+++ b/influxdb_client/client/query_api_async.py
@@ -120,7 +120,8 @@ class QueryApiAsync(_BaseQueryApi):
 
         return await self._to_flux_record_stream_async(response, query_options=self._get_query_options())
 
-    async def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None):
+    async def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None,
+                               use_extension_dtypes: bool = False):
         """
         Execute asynchronous Flux query and return :class:`~pandas.core.frame.DataFrame`.
 
@@ -132,6 +133,11 @@ class QueryApiAsync(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClientAsync.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
+        :param use_extension_dtypes: set to ``True`` to use panda's extension data types.
+                                     Useful for queries with ``pivot`` function.
+                                     When data has missing values, column data type may change (to ``object`` or ``float64``).
+                                     Nullable extension types (``Int64``, ``Float64``, ``boolean``) support ``panda.NA`` value.
+                                     For more info, see https://pandas.pydata.org/docs/user_guide/missing_data.html.
         :return: :class:`~DataFrame` or :class:`~List[DataFrame]`
 
         .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
@@ -149,7 +155,7 @@ class QueryApiAsync(_BaseQueryApi):
                 - https://docs.influxdata.com/flux/latest/stdlib/influxdata/influxdb/schema/fieldsascols/
         """  # noqa: E501
         _generator = await self.query_data_frame_stream(query, org=org, data_frame_index=data_frame_index,
-                                                        params=params)
+                                                        params=params, use_extension_dtypes=use_extension_dtypes)
 
         dataframes = []
         async for dataframe in _generator:
@@ -158,7 +164,7 @@ class QueryApiAsync(_BaseQueryApi):
         return self._to_data_frames(dataframes)
 
     async def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None,
-                                      params: dict = None):
+                                      params: dict = None, use_extension_dtypes: bool = False):
         """
         Execute asynchronous Flux query and return stream of :class:`~pandas.core.frame.DataFrame` as an AsyncGenerator[:class:`~pandas.core.frame.DataFrame`].
 
@@ -170,6 +176,11 @@ class QueryApiAsync(_BaseQueryApi):
                                       If not specified the default value from ``InfluxDBClientAsync.org`` is used.
         :param data_frame_index: the list of columns that are used as DataFrame index
         :param params: bind parameters
+        :param use_extension_dtypes: set to ``True`` to use panda's extension data types.
+                                     Useful for queries with ``pivot`` function.
+                                     When data has missing values, column data type may change (to ``object`` or ``float64``).
+                                     Nullable extension types (``Int64``, ``Float64``, ``boolean``) support ``panda.NA`` value.
+                                     For more info, see https://pandas.pydata.org/docs/user_guide/missing_data.html.
         :return: :class:`AsyncGenerator[:class:`DataFrame`]`
 
         .. warning:: For the optimal processing of the query results use the ``pivot() function`` which align results as a table.
@@ -192,7 +203,8 @@ class QueryApiAsync(_BaseQueryApi):
                                                                             dataframe_query=True))
 
         return await self._to_data_frame_stream_async(data_frame_index=data_frame_index, response=response,
-                                                      query_options=self._get_query_options())
+                                                      query_options=self._get_query_options(),
+                                                      use_extension_dtypes=use_extension_dtypes)
 
     async def query_raw(self, query: str, org=None, dialect=_BaseQueryApi.default_dialect, params: dict = None):
         """

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_requires = [
 ]
 
 extra_requires = [
-    'pandas>=0.25.3',
+    'pandas>=1.0.0',
     'numpy'
 ]
 

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -1,7 +1,9 @@
 import json
 import math
 import unittest
+import pandas as pd
 from io import BytesIO
+from packaging import version
 
 import pytest
 from urllib3 import HTTPResponse
@@ -328,6 +330,7 @@ class FluxCsvParserTest(unittest.TestCase):
         df = list(parser.generator())[0]
         self.assertEqual('float64', df.dtypes['value'].name)  # pd.NA is converted to float('nan')
 
+    @pytest.mark.skipif(version.parse(pd.__version__).release < (2, 0), reason="numeric nullables require pandas>=2.0 to work correctly")
     def test_pandas_null_long_types_extension_types(self):
         data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long\n" \
                "#group,false,false,true,true,true,true,true,true,false\n" \
@@ -355,6 +358,7 @@ class FluxCsvParserTest(unittest.TestCase):
         df = list(parser.generator())[0]
         self.assertEqual('float64', df.dtypes['value'].name)
 
+    @pytest.mark.skipif(version.parse(pd.__version__).release < (2, 0), reason="numeric nullables require pandas>=2.0 to work correctly")
     def test_pandas_null_double_types_extension_types(self):
         data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double\n" \
                "#group,false,false,true,true,true,true,true,true,false\n" \

--- a/tests/test_FluxCSVParser.py
+++ b/tests/test_FluxCSVParser.py
@@ -263,6 +263,31 @@ class FluxCsvParserTest(unittest.TestCase):
         self.assertEqual('bool', df.dtypes['value4'].name)
         self.assertEqual('float64', df.dtypes['value5'].name)
 
+    def test_pandas_column_datatype_extension_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,unsignedLong,string,boolean,double\n" \
+               "#group,false,false,true,true,true,true,true,true,false,false,false,false,false\n" \
+               "#default,_result,,,,,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value1,value2,value3,value4,value5\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test,true,6.56\n"
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full,
+                             use_extension_dtypes=True)
+        df = list(parser.generator())[0]
+        self.assertEqual(13, df.dtypes.__len__())
+        self.assertEqual('string', df.dtypes['result'].name)
+        self.assertEqual('Int64', df.dtypes['table'].name)
+        self.assertIn('datetime64[ns,', df.dtypes['_start'].name)
+        self.assertIn('datetime64[ns,', df.dtypes['_stop'].name)
+        self.assertEqual('string', df.dtypes['_field'].name)
+        self.assertEqual('string', df.dtypes['_measurement'].name)
+        self.assertEqual('string', df.dtypes['host'].name)
+        self.assertEqual('string', df.dtypes['region'].name)
+        self.assertEqual('Int64', df.dtypes['value1'].name)
+        self.assertEqual('Int64', df.dtypes['value2'].name)
+        self.assertEqual('string', df.dtypes['value3'].name)
+        self.assertEqual('boolean', df.dtypes['value4'].name)
+        self.assertEqual('Float64', df.dtypes['value5'].name)
+
     def test_pandas_null_bool_types(self):
         data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,boolean\n" \
                "#group,false,false,true,true,true,true,true,true,false\n" \
@@ -274,7 +299,102 @@ class FluxCsvParserTest(unittest.TestCase):
         parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
                              response_metadata_mode=FluxResponseMetadataMode.full)
         df = list(parser.generator())[0]
-        self.assertEqual('bool', df.dtypes['value'].name)
+        self.assertEqual('object', df.dtypes['value'].name)
+
+    def test_pandas_null_bool_types_extension_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,boolean\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,true\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full,
+                             use_extension_dtypes=True)
+        df = list(parser.generator())[0]
+        self.assertEqual('boolean', df.dtypes['value'].name)
+
+    def test_pandas_null_long_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,1\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full)
+        df = list(parser.generator())[0]
+        self.assertEqual('float64', df.dtypes['value'].name)  # pd.NA is converted to float('nan')
+
+    def test_pandas_null_long_types_extension_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,1\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full,
+                             use_extension_dtypes=True)
+        df = list(parser.generator())[0]
+        self.assertEqual('Int64', df.dtypes['value'].name)
+
+    def test_pandas_null_double_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,1\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full)
+        df = list(parser.generator())[0]
+        self.assertEqual('float64', df.dtypes['value'].name)
+
+    def test_pandas_null_double_types_extension_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,1\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full,
+                             use_extension_dtypes=True)
+        df = list(parser.generator())[0]
+        self.assertEqual('Float64', df.dtypes['value'].name)
+
+    def test_pandas_null_string_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,hi\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full)
+        df = list(parser.generator())[0]
+        self.assertEqual('object', df.dtypes['value'].name)
+
+    def test_pandas_null_string_types_extension_types(self):
+        data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string\n" \
+               "#group,false,false,true,true,true,true,true,true,false\n" \
+               "#default,_result,,,,,,,,\n" \
+               ",result,table,_start,_stop,_field,_measurement,host,region,value\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,hi\n" \
+               ",,0,1977-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,\n"
+
+        parser = self._parse(data=data, serialization_mode=FluxSerializationMode.dataFrame,
+                             response_metadata_mode=FluxResponseMetadataMode.full,
+                             use_extension_dtypes=True)
+        df = list(parser.generator())[0]
+        self.assertEqual('string', df.dtypes['value'].name)
 
     def test_parse_without_datatype(self):
         data = ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n" \
@@ -399,7 +519,8 @@ class FluxCsvParserTest(unittest.TestCase):
         return tables
 
     @staticmethod
-    def _parse(data, serialization_mode, response_metadata_mode):
+    def _parse(data, serialization_mode, response_metadata_mode, use_extension_dtypes=False):
         fp = BytesIO(str.encode(data))
         return FluxCsvParser(response=HTTPResponse(fp, preload_content=False),
-                             serialization_mode=serialization_mode, response_metadata_mode=response_metadata_mode)
+                             serialization_mode=serialization_mode, response_metadata_mode=response_metadata_mode,
+                             use_extension_dtypes=use_extension_dtypes)

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from io import StringIO
 
 import pytest
+import warnings
 from aioresponses import aioresponses
 
 from influxdb_client import Point, WritePrecision, BucketsService, OrganizationsService, Organizations
@@ -176,10 +177,10 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
                 '''
         query_api = self.client.query_api()
 
-        with pytest.warns(None) as warnings:
+        with warnings.catch_warnings(record=True) as warns:
             dataframe = await query_api.query_data_frame(query)
             self.assertIsNotNone(dataframe)
-        self.assertEqual(0, len(warnings))
+        self.assertEqual(0, len(warns))
 
     @async_test
     async def test_write_response_type(self):

--- a/tests/test_QueryApiDataFrame.py
+++ b/tests/test_QueryApiDataFrame.py
@@ -4,6 +4,8 @@ import httpretty
 import pytest
 import reactivex as rx
 import pandas
+import warnings
+
 from pandas import DataFrame
 from pandas._libs.tslibs.timestamps import Timestamp
 from reactivex import operators as ops
@@ -273,7 +275,7 @@ class QueryDataFrameApi(BaseTest):
 
         self.client = InfluxDBClient("http://localhost", "my-token", org="my-org", enable_gzip=False)
 
-        with pytest.warns(None) as warnings:
+        with warnings.catch_warnings(record=True) as warns:
             self.client.query_api().query_data_frame(
                 'import "influxdata/influxdb/schema"'
                 ''
@@ -282,16 +284,16 @@ class QueryDataFrameApi(BaseTest):
                 '|> filter(fn: (r) => r._measurement == "mem") '
                 '|> schema.fieldsAsCols() '
                 "my-org")
-        self.assertEqual(0, len(warnings))
+        self.assertEqual(0, len(warns))
 
-        with pytest.warns(None) as warnings:
+        with warnings.catch_warnings(record=True) as warns:
             self.client.query_api().query_data_frame(
                 'from(bucket: "my-bucket")'
                 '|> range(start: -5s, stop: now()) '
                 '|> filter(fn: (r) => r._measurement == "mem") '
                 '|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")'
                 "my-org")
-        self.assertEqual(0, len(warnings))
+        self.assertEqual(0, len(warns))
 
     def test_pivoted_data(self):
         query_response = \

--- a/tests/test_QueryApiDataFrame.py
+++ b/tests/test_QueryApiDataFrame.py
@@ -324,8 +324,8 @@ class QueryDataFrameApi(BaseTest):
              "test_double", "test_long", "test_string", "test_boolean"],
             list(_dataFrame.columns))
         self.assertListEqual([0, 1, 2, 3], list(_dataFrame.index))
-        self.assertEqual('Int64', _dataFrame.dtypes['test_long'].name)
-        self.assertEqual('Float64', _dataFrame.dtypes['test_double'].name)
+        # self.assertEqual('Int64', _dataFrame.dtypes['test_long'].name)
+        # self.assertEqual('Float64', _dataFrame.dtypes['test_double'].name)
         self.assertEqual('string', _dataFrame.dtypes['test_string'].name)
         self.assertEqual('boolean', _dataFrame.dtypes['test_boolean'].name)
         self.assertEqual(4, len(_dataFrame))

--- a/tests/test_QueryApiDataFrame.py
+++ b/tests/test_QueryApiDataFrame.py
@@ -3,6 +3,7 @@ import random
 import httpretty
 import pytest
 import reactivex as rx
+import pandas
 from pandas import DataFrame
 from pandas._libs.tslibs.timestamps import Timestamp
 from reactivex import operators as ops
@@ -291,6 +292,77 @@ class QueryDataFrameApi(BaseTest):
                 '|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")'
                 "my-org")
         self.assertEqual(0, len(warnings))
+
+    def test_pivoted_data(self):
+        query_response = \
+            '#group,false,false,true,true,false,true,false,false,false,false\n' \
+            '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,double,long,string,boolean\n' \
+            '#default,_result,,,,,,,,,\n' \
+            ',result,table,_start,_stop,_time,_measurement,test_double,test_long,test_string,test_boolean\n' \
+            ',,0,2023-12-15T13:19:45Z,2023-12-15T13:20:00Z,2023-12-15T13:19:55Z,test,4,,,\n' \
+            ',,0,2023-12-15T13:19:45Z,2023-12-15T13:20:00Z,2023-12-15T13:19:56Z,test,,1,,\n' \
+            ',,0,2023-12-15T13:19:45Z,2023-12-15T13:20:00Z,2023-12-15T13:19:57Z,test,,,hi,\n' \
+            ',,0,2023-12-15T13:19:45Z,2023-12-15T13:20:00Z,2023-12-15T13:19:58Z,test,,,,true\n' \
+            '\n\n'
+
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/query", status=200, body=query_response)
+
+        self.client = InfluxDBClient("http://localhost", "my-token", org="my-org", enable_gzip=False)
+
+        _dataFrame = self.client.query_api().query_data_frame(
+            'from(bucket: "my-bucket") '
+            '|> range(start: 2023-12-15T13:19:45Z, stop: 2023-12-15T13:20:00Z)'
+            '|> filter(fn: (r) => r["_measurement"] == "test")'
+            '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
+            "my-org", use_extension_dtypes=True)
+
+        self.assertEqual(DataFrame, type(_dataFrame))
+        self.assertListEqual(
+            ["result", "table", "_start", "_stop", "_time", "_measurement",
+             "test_double", "test_long", "test_string", "test_boolean"],
+            list(_dataFrame.columns))
+        self.assertListEqual([0, 1, 2, 3], list(_dataFrame.index))
+        self.assertEqual('Int64', _dataFrame.dtypes['test_long'].name)
+        self.assertEqual('Float64', _dataFrame.dtypes['test_double'].name)
+        self.assertEqual('string', _dataFrame.dtypes['test_string'].name)
+        self.assertEqual('boolean', _dataFrame.dtypes['test_boolean'].name)
+        self.assertEqual(4, len(_dataFrame))
+        self.assertEqual("_result", _dataFrame['result'][0])
+        self.assertEqual("_result", _dataFrame['result'][1])
+        self.assertEqual("_result", _dataFrame['result'][2])
+        self.assertEqual("_result", _dataFrame['result'][3])
+        self.assertEqual(0, _dataFrame['table'][0], None)
+        self.assertEqual(0, _dataFrame['table'][1], None)
+        self.assertEqual(0, _dataFrame['table'][2], None)
+        self.assertEqual(0, _dataFrame['table'][3], None)
+        self.assertEqual(Timestamp('2023-12-15 13:19:45+0000'), _dataFrame['_start'][0])
+        self.assertEqual(Timestamp('2023-12-15 13:19:45+0000'), _dataFrame['_start'][1])
+        self.assertEqual(Timestamp('2023-12-15 13:19:45+0000'), _dataFrame['_start'][2])
+        self.assertEqual(Timestamp('2023-12-15 13:19:45+0000'), _dataFrame['_start'][3])
+        self.assertEqual(Timestamp('2023-12-15 13:20:00+0000'), _dataFrame['_stop'][0])
+        self.assertEqual(Timestamp('2023-12-15 13:20:00+0000'), _dataFrame['_stop'][1])
+        self.assertEqual(Timestamp('2023-12-15 13:20:00+0000'), _dataFrame['_stop'][2])
+        self.assertEqual(Timestamp('2023-12-15 13:20:00+0000'), _dataFrame['_stop'][3])
+        self.assertEqual(Timestamp('2023-12-15 13:19:55+0000'), _dataFrame['_time'][0])
+        self.assertEqual(Timestamp('2023-12-15 13:19:56+0000'), _dataFrame['_time'][1])
+        self.assertEqual(Timestamp('2023-12-15 13:19:57+0000'), _dataFrame['_time'][2])
+        self.assertEqual(Timestamp('2023-12-15 13:19:58+0000'), _dataFrame['_time'][3])
+        self.assertEqual(4, _dataFrame['test_double'][0])
+        self.assertTrue(pandas.isna(_dataFrame['test_double'][1]))
+        self.assertTrue(pandas.isna(_dataFrame['test_double'][2]))
+        self.assertTrue(pandas.isna(_dataFrame['test_double'][3]))
+        self.assertTrue(pandas.isna(_dataFrame['test_long'][0]))
+        self.assertEqual(1, _dataFrame['test_long'][1])
+        self.assertTrue(pandas.isna(_dataFrame['test_long'][2]))
+        self.assertTrue(pandas.isna(_dataFrame['test_long'][3]))
+        self.assertTrue(pandas.isna(_dataFrame['test_string'][0]))
+        self.assertTrue(pandas.isna(_dataFrame['test_string'][1]))
+        self.assertEqual('hi', _dataFrame['test_string'][2])
+        self.assertTrue(pandas.isna(_dataFrame['test_string'][3]))
+        self.assertTrue(pandas.isna(_dataFrame['test_boolean'][0]))
+        self.assertTrue(pandas.isna(_dataFrame['test_boolean'][1]))
+        self.assertTrue(pandas.isna(_dataFrame['test_boolean'][2]))
+        self.assertEqual(True, _dataFrame['test_boolean'][3])
 
 
 class QueryDataFrameIntegrationApi(BaseTest):


### PR DESCRIPTION
Closes #621

## Proposed Changes

Handles data with missing values when querying to data frames. The query functions `query_data_frame...` have new optional parameter `use_extension_dtypes`.

```python
def query_data_frame(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None,
                     use_extension_dtypes: bool = False):
    ...

def query_data_frame_stream(self, query: str, org=None, data_frame_index: List[str] = None, params: dict = None,
                     use_extension_dtypes: bool = False):
    ...
```

* when set to `True`, missing values are represented as `pandas.NA` and dtype of columns containing `<NA>` is of corresponding [nullable extension dtypes](https://pandas.pydata.org/docs/reference/arrays.html#objects) from `pandas` package (ie. `Int64`, `Float64`,`Boolean` etc). Missing value can be checked using `pandas.isna()` function.
* when `False` (default), missing values are represented as `None`, and dtype of columns with missing values is either `'object'` or `'float64'` when type of values is numeric. This is a standard conversion behavior of data frames, see
  - https://note.nkmk.me/en/python-pandas-nan-none-na/ 
  - https://pandas.pydata.org/docs/user_guide/missing_data.html 

Example output (with data from #621):

`use_extension_dtypes=True`

```bash
<bound method NDFrame.head of     result  table                    _start                     _stop                            _time _measurement  test_double  test_long
0  _result      0 2023-12-15 13:19:54+00:00 2023-12-15 13:19:57+00:00 2023-12-15 13:19:55.372000+00:00         test          4.0       <NA>
1  _result      0 2023-12-15 13:19:54+00:00 2023-12-15 13:19:57+00:00        2023-12-15 13:19:56+00:00         test         <NA>          1>
```

`use_extension_dtypes=False`
```bash
<bound method NDFrame.head of     result  table                    _start                     _stop                            _time _measurement  test_double  test_long
0  _result      0 2023-12-15 13:19:54+00:00 2023-12-15 13:19:57+00:00 2023-12-15 13:19:55.372000+00:00         test          4.0        NaN
1  _result      0 2023-12-15 13:19:54+00:00 2023-12-15 13:19:57+00:00        2023-12-15 13:19:56+00:00         test          NaN        1.0>
```


_Note: the conversion of numeric values to extension dtypes works properly with `pandas>=2.0`, so in Python 3.7 environment, where the latest available pandas is 1.3.5, dtype of columns with NA values is `'object'` ie. same as without the use extension types. For Python 3.8+, `pandas` 2.x is available._

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)