### PR TITLE
fix: Pandas 3.0 warning for inplace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Bug Fixes
+1. Pandas 3.0 warning silenced
+
 ## 1.41.0 [unreleased]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-### Bug Fixes
-1. Pandas 3.0 warning silenced
-
 ## 1.41.0 [unreleased]
 
 ### Bug Fixes
 1. [#636](https://github.com/influxdata/influxdb-client-python/pull/636): Handle missing data in data frames
-2. [#638](https://github.com/influxdata/influxdb-client-python/pull/638): Refactor DataFrame operations to avoid chained assignment and resolve FutureWarning in pandas, ensuring compatibility with pandas 3.0.
+2. [#638](https://github.com/influxdata/influxdb-client-python/pull/638), [#642](https://github.com/influxdata/influxdb-client-python/pull/642): Refactor DataFrame operations to avoid chained assignment and resolve FutureWarning in pandas, ensuring compatibility with pandas 3.0.
 
 ### Documentation
 1. [#639](https://github.com/influxdata/influxdb-client-python/pull/639): Use Markdown for `README`

--- a/influxdb_client/client/write/dataframe_serializer.py
+++ b/influxdb_client/client/write/dataframe_serializer.py
@@ -234,7 +234,7 @@ class DataframeSerializer:
 
         for k, v in dict(data_frame.dtypes).items():
             if k in data_frame_tag_columns:
-                data_frame.replace({k: ''}, np.nan, inplace=True)
+                data_frame = data_frame.replace({k: ''}, np.nan)
 
         self.data_frame = data_frame
         self.f = f


### PR DESCRIPTION
Related #637

## Proposed Changes

Currently, the following warning for inplace methods in the upcoming Pandas 3.0 is triggered.

```
~/.venv/lib/python3.11/site-packages/influxdb_client/client/write/dataframe_serializer.py:237: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.
```

The pull request silences the warning.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
