### PR TITLE
Add lower-to-higher precision conversion in _convert_timestamp

### DIFF
--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -341,12 +341,12 @@ def _convert_timestamp(timestamp, precision=DEFAULT_WRITE_PRECISION):
     if isinstance(timestamp, str):
         timestamp = date_helper.parse_date(timestamp)
 
-    if isinstance(timestamp, timedelta) or isinstance(timestamp, datetime):
+    if isinstance(timestamp, timedelta) or isinstance(timestamp, datetime) or isinstance(timestamp, Decimal):
 
         if isinstance(timestamp, datetime):
             timestamp = date_helper.to_utc(timestamp) - EPOCH
 
-        ns = date_helper.to_nanoseconds(timestamp)
+        ns = int(date_helper.to_nanoseconds(timestamp))
 
         if precision is None or precision == WritePrecision.NS:
             return ns


### PR DESCRIPTION
Closes #

## Proposed Changes

Currently the `_convert_timestamp` util only supports higher precision to lower precision time conversion. Some of the usecases might need the opposite, and instead of writing on our own we wish to use this already present utility. In my usecase the data is in floating point as seconds which I might want to convert to nanoseconds or other precision. So did some small changes.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
