### PR TITLE
refactor: to timezone specific datetime helper to avoid use deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.45.0 [unreleased]
 
+### Bug Fixes
+1. [#652](https://github.com/influxdata/influxdb-client-python/pull/652): Refactor to `timezone` specific `datetime` helpers to avoid use deprecated functions
+
 ## 1.44.0 [2024-06-24]
 
 ### Features
@@ -13,9 +16,6 @@
 
 ### Others
 1. [#654](https://github.com/influxdata/influxdb-client-python/pull/654): Enable packaging type information - `py.typed`
-
-### Bug Fixes
-1. [#652](https://github.com/influxdata/influxdb-client-python/pull/652): Refactor to `timezone` specific `datetime` helpers to avoid use deprecated functions
 
 ## 1.42.0 [2024-04-17]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Others
 1. [#654](https://github.com/influxdata/influxdb-client-python/pull/654): Enable packaging type information - `py.typed`
 
+### Bug Fixes
+1. [#652](https://github.com/influxdata/influxdb-client-python/pull/652): Refactor to `timezone` specific `datetime` helpers to avoid use deprecated functions
+
 ## 1.42.0 [2024-04-17]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ The batching is configurable by `write_options`:
 | **exponential_base** | the base for the exponential retry delay, the next delay is computed using random exponential backoff as a random value within the interval `retry_interval * exponential_base^(attempts-1)` and `retry_interval * exponential_base^(attempts)`. Example for `retry_interval=5_000, exponential_base=2, max_retry_delay=125_000, total=5` Retry delays are random distributed values within the ranges of `[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]` | `2`           |
 
 ``` python
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import reactivex as rx
@@ -456,7 +456,7 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
         """
         Write Pandas DataFrame
         """
-        _now = datetime.utcnow()
+        _now = datetime.now(tz=timezone.utc)
         _data_frame = pd.DataFrame(data=[["coyote_creek", 1.0], ["coyote_creek", 2.0]],
                                    index=[_now, _now + timedelta(hours=1)],
                                    columns=["location", "water_level"])
@@ -923,7 +923,7 @@ The last step is run a python script via: `python3 influx_cloud.py`.
 Connect to InfluxDB 2.0 - write data and query them
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from influxdb_client import Point, InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -945,7 +945,7 @@ try:
     """
     Write data by Point structure
     """
-    point = Point(kind).tag('host', host).tag('device', device).field('value', 25.3).time(time=datetime.utcnow())
+    point = Point(kind).tag('host', host).tag('device', device).field('value', 25.3).time(time=datetime.now(tz=timezone.utc))
 
     print(f'Writing to InfluxDB cloud: {point.to_line_protocol()} ...')
 
@@ -1407,7 +1407,7 @@ The `influxdb_client.client.query_api_async.QueryApiAsync` supports retrieve dat
 >
 > async def main():
 >     async with InfluxDBClientAsync(url="http://localhost:8086", token="my-token", org="my-org") as client:
->         start = datetime.utcfromtimestamp(0)
+>         start = datetime.fromtimestamp(0)
 >         stop = datetime.now()
 >         # Delete data with location = 'Prague'
 >         successfully = await client.delete_api().delete(start=start, stop=stop, bucket="my-bucket",

--- a/examples/asynchronous.py
+++ b/examples/asynchronous.py
@@ -76,7 +76,7 @@ async def main():
         Delete data
         """
         print(f"\n------- Delete data with location = 'Prague' -------\n")
-        successfully = await client.delete_api().delete(start=datetime.utcfromtimestamp(0), stop=datetime.now(),
+        successfully = await client.delete_api().delete(start=datetime.fromtimestamp(0), stop=datetime.now(),
                                                         predicate="location = \"Prague\"", bucket="my-bucket")
         print(f" > successfully: {successfully}")
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,5 +1,5 @@
 import codecs
-from datetime import datetime
+from datetime import datetime, timezone
 
 from influxdb_client import WritePrecision, InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -7,8 +7,8 @@ from influxdb_client.client.write_api import SYNCHRONOUS
 with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org", debug=False) as client:
     query_api = client.query_api()
 
-    p = Point("my_measurement").tag("location", "Prague").field("temperature", 25.3).time(datetime.utcnow(),
-                                                                                          WritePrecision.MS)
+    p = Point("my_measurement").tag("location", "Prague").field("temperature", 25.3) \
+        .time(datetime.now(tz=timezone.utc), WritePrecision.MS)
     write_api = client.write_api(write_options=SYNCHRONOUS)
 
     # write using point structure

--- a/examples/influx_cloud.py
+++ b/examples/influx_cloud.py
@@ -2,7 +2,7 @@
 Connect to InfluxDB 2.0 - write data and query them
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from influxdb_client import Point, InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -23,7 +23,8 @@ with InfluxDBClient(url=influx_cloud_url, token=influx_cloud_token) as client:
     """
     Write data by Point structure
     """
-    point = Point(kind).tag('host', host).tag('device', device).field('value', 25.3).time(time=datetime.utcnow())
+    point = Point(kind).tag('host', host).tag('device', device).field('value', 25.3) \
+        .time(time=datetime.now(tz=timezone.utc))
 
     print(f'Writing to InfluxDB cloud: {point.to_line_protocol()} ...')
 

--- a/examples/logging_handler.py
+++ b/examples/logging_handler.py
@@ -45,7 +45,7 @@ def use_logger():
         Point('my-measurement')
             .tag('host', 'host1')
             .field('temperature', 25.3)
-            .time(datetime.datetime.utcnow(), WritePrecision.MS)
+            .time(datetime.datetime.now(tz=datetime.timezone.utc), WritePrecision.MS)
     )
 
 

--- a/examples/write_structured_data.py
+++ b/examples/write_structured_data.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
@@ -37,7 +37,7 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
                     version="2021.06.05.5874",
                     pressure=125,
                     temperature=10,
-                    timestamp=datetime.utcnow())
+                    timestamp=datetime.now(tz=timezone.utc))
     print(sensor)
 
     """

--- a/influxdb_client/client/write/point.py
+++ b/influxdb_client/client/write/point.py
@@ -10,7 +10,7 @@ from numbers import Integral
 from influxdb_client.client.util.date_utils import get_date_helper
 from influxdb_client.domain.write_precision import WritePrecision
 
-EPOCH = datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
+EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
 
 DEFAULT_WRITE_PRECISION = WritePrecision.NS
 

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import unittest
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from io import StringIO
 
 import pytest
@@ -202,11 +202,11 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
     async def test_write_points_different_precision(self):
         measurement = generate_name("measurement")
         _point1 = Point(measurement).tag("location", "Prague").field("temperature", 25.3) \
-            .time(datetime.utcfromtimestamp(0), write_precision=WritePrecision.S)
+            .time(datetime.fromtimestamp(0, tz=timezone.utc), write_precision=WritePrecision.S)
         _point2 = Point(measurement).tag("location", "New York").field("temperature", 24.3) \
-            .time(datetime.utcfromtimestamp(1), write_precision=WritePrecision.MS)
+            .time(datetime.fromtimestamp(1, tz=timezone.utc), write_precision=WritePrecision.MS)
         _point3 = Point(measurement).tag("location", "Berlin").field("temperature", 24.3) \
-            .time(datetime.utcfromtimestamp(2), write_precision=WritePrecision.NS)
+            .time(datetime.fromtimestamp(2, tz=timezone.utc), write_precision=WritePrecision.NS)
         await self.client.write_api().write(bucket="my-bucket", record=[_point1, _point2, _point3],
                                             write_precision=WritePrecision.NS)
         query = f'''
@@ -228,7 +228,8 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         measurement = generate_name("measurement")
         await self._prepare_data(measurement)
 
-        successfully = await self.client.delete_api().delete(start=datetime.utcfromtimestamp(0), stop=datetime.utcnow(),
+        successfully = await self.client.delete_api().delete(start=datetime.fromtimestamp(0),
+                                                             stop=datetime.now(tz=timezone.utc),
                                                              predicate="location = \"Prague\"", bucket="my-bucket")
         self.assertEqual(True, successfully)
         query = f'''

--- a/tests/test_MultiprocessingWriter.py
+++ b/tests/test_MultiprocessingWriter.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from influxdb_client import WritePrecision, InfluxDBClient
 from influxdb_client.client.util.date_utils import get_date_helper
@@ -53,7 +53,7 @@ class MultiprocessingWriterTest(unittest.TestCase):
             self.assertIsNotNone(writer)
 
     def test_pass_parameters(self):
-        unique = get_date_helper().to_nanoseconds(datetime.utcnow() - datetime.utcfromtimestamp(0))
+        unique = get_date_helper().to_nanoseconds(datetime.now(tz=timezone.utc) - datetime.fromtimestamp(0, tz=timezone.utc))
 
         # write data
         with MultiprocessingWriter(url=self.url, token=self.token, org=self.org, write_options=SYNCHRONOUS) as writer:
@@ -69,4 +69,4 @@ class MultiprocessingWriterTest(unittest.TestCase):
             self.assertIsNotNone(record)
             self.assertEqual("a", record["tag"])
             self.assertEqual(5, record["_value"])
-            self.assertEqual(get_date_helper().to_utc(datetime.utcfromtimestamp(10)), record["_time"])
+            self.assertEqual(get_date_helper().to_utc(datetime.fromtimestamp(10, tz=timezone.utc)), record["_time"])

--- a/tests/test_PandasDateTimeHelper.py
+++ b/tests/test_PandasDateTimeHelper.py
@@ -23,7 +23,7 @@ class PandasDateTimeHelperTest(unittest.TestCase):
 
     def test_to_nanoseconds(self):
         date = self.helper.parse_date('2020-08-07T06:21:57.331249158Z').replace(tzinfo=timezone.utc)
-        nanoseconds = self.helper.to_nanoseconds(date - datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc))
+        nanoseconds = self.helper.to_nanoseconds(date - datetime.fromtimestamp(0, tz=timezone.utc))
 
         self.assertEqual(nanoseconds, 1596781317331249158)
 


### PR DESCRIPTION
Closes #603

## Proposed Changes

![image](https://github.com/influxdata/influxdb-client-python/assets/455137/75982ef8-f743-4d75-b808-5aea27978db3)
![image](https://github.com/influxdata/influxdb-client-python/assets/455137/26771d81-1139-4c2f-86dc-20f4f57828af)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
