### PR TITLE
fix: packaging type info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 1. [#655](https://github.com/influxdata/influxdb-client-python/pull/655): Replace deprecated `urllib` calls `HTTPResponse.getheaders()` and `HTTPResponse.getheader()`.
 
+### Others
+1. [#654](https://github.com/influxdata/influxdb-client-python/pull/654): Enable packaging type information - `py.typed`
+
 ## 1.42.0 [2024-04-17]
 
 ### Bug Fixes


### PR DESCRIPTION
Closes #622

## Proposed Changes

This adds PEP 561 distributing and packaging type information, which specifically resolves issue with MyPy
`error: Skipping analyzing "influxdb_client": module is installed, but missing library stubs or py.typed marker [import-untyped]`

The required marker really is just an empty file `py.typed`. The same fix has been applied in v3 client.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)