### PR TITLE
fix: deprecated urllib calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.43.0 [unreleased]
 
+### Bug Fixes
+1. [#655](https://github.com/influxdata/influxdb-client-python/pull/655): Replace deprecated `urllib` calls `HTTPResponse.getheaders()` and `HTTPResponse.getheader()`.
+
 ## 1.42.0 [2024-04-17]
 
 ### Bug Fixes

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -15,7 +15,10 @@ class InfluxDBError(Exception):
         if response is not None:
             self.response = response
             self.message = self._get_message(response)
-            self.retry_after = response.headers.get('Retry-After')
+            if isinstance(response, HTTPResponse):  # response is HTTPResponse
+                self.retry_after = response.headers.get('Retry-After')
+            else:  # response is RESTResponse
+                self.retry_after = response.getheader('Retry-After')
         else:
             self.response = None
             self.message = message or 'no response'

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -15,7 +15,7 @@ class InfluxDBError(Exception):
         if response is not None:
             self.response = response
             self.message = self._get_message(response)
-            self.retry_after = response.getheader('Retry-After')
+            self.retry_after = response.headers.get('Retry-After')
         else:
             self.response = None
             self.message = message or 'no response'
@@ -34,7 +34,7 @@ class InfluxDBError(Exception):
 
         # Header
         for header_key in ["X-Platform-Error-Code", "X-Influx-Error", "X-InfluxDb-Error"]:
-            header_value = response.getheader(header_key)
+            header_value = response.headers.get(header_key)
             if header_value is not None:
                 return header_value
 

--- a/influxdb_client/client/exceptions.py
+++ b/influxdb_client/client/exceptions.py
@@ -34,7 +34,7 @@ class InfluxDBError(Exception):
 
         # Header
         for header_key in ["X-Platform-Error-Code", "X-Influx-Error", "X-InfluxDb-Error"]:
-            header_value = response.headers.get(header_key)
+            header_value = response.getheader(header_key)
             if header_value is not None:
                 return header_value
 

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -34,7 +34,7 @@ class ApiException(InfluxDBError):
             self.status = http_resp.status
             self.reason = http_resp.reason
             self.body = http_resp.data
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
         else:
             self.status = status
             self.reason = reason

--- a/influxdb_client/rest.py
+++ b/influxdb_client/rest.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 
 import logging
 from typing import Dict
-
+from urllib3 import HTTPResponse
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.configuration import Configuration
 
@@ -34,7 +34,10 @@ class ApiException(InfluxDBError):
             self.status = http_resp.status
             self.reason = http_resp.reason
             self.body = http_resp.data
-            self.headers = http_resp.headers
+            if isinstance(http_resp, HTTPResponse):  # response is HTTPResponse
+                self.headers = http_resp.headers
+            else:  # response is RESTResponse
+                self.headers = http_resp.getheaders()
         else:
             self.status = status
             self.reason = reason


### PR DESCRIPTION
Closes #602 

## Proposed Changes

Replaces deprecated `urllib` lib calls:
* `HTTPResponse.getheaders()` with HTTPResponse.headers`
* `HTTPResponse.getheader(name, default)` with `HTTPResponse.headers.get(name, default)`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
