### PR TITLE
perf: Prefer datetime.fromisoformat over dateutil.parse in Python 3.11+ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.44.0 [unreleased]
 
+### Performance
+1. [#657](https://github.com/influxdata/influxdb-client-python/pull/657): Prefer datetime.fromisoformat over dateutil.parse in Python 3.11+ 
+
 ## 1.43.0 [2024-05-17]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.44.0 [unreleased]
 
-### Performance
+### Features
 1. [#657](https://github.com/influxdata/influxdb-client-python/pull/657): Prefer datetime.fromisoformat over dateutil.parse in Python 3.11+ 
 
 ## 1.43.0 [2024-05-17]

--- a/influxdb_client/client/util/date_utils.py
+++ b/influxdb_client/client/util/date_utils.py
@@ -1,5 +1,6 @@
 """Utils to get right Date parsing function."""
 import datetime
+from sys import version_info
 import threading
 from datetime import timezone as tz
 
@@ -78,7 +79,8 @@ def get_date_helper() -> DateHelper:
     """
     Return DateHelper with proper implementation.
 
-    If there is a 'ciso8601' than use 'ciso8601.parse_datetime' else use 'dateutil.parse'.
+    If there is a 'ciso8601' than use 'ciso8601.parse_datetime' else
+    use 'datetime.fromisoformat' (Python >= 3.11) or 'dateutil.parse' (Python < 3.11).
     """
     global date_helper
     if date_helper is None:
@@ -90,7 +92,10 @@ def get_date_helper() -> DateHelper:
                     import ciso8601
                     _date_helper.parse_date = ciso8601.parse_datetime
                 except ModuleNotFoundError:
-                    _date_helper.parse_date = parser.parse
+                    if (version_info.major, version_info.minor) >= (3, 11):
+                        _date_helper.parse_date = datetime.datetime.fromisoformat
+                    else:
+                        _date_helper.parse_date = parser.parse
                 date_helper = _date_helper
 
     return date_helper


### PR DESCRIPTION
## Proposed Changes

This PR changes the behavior of `get_date_helper` to prefer `datetime.datetime.fromisoformat` over `dateutil.parser` in Python 3.11 or higher.
According to https://github.com/closeio/ciso8601/blob/b17984f5b4c6db0ef596b4d31456c8a39ae278ee/why_ciso8601.md, `Since Python 3.11+, the performance of cPython's datetime.fromisoformat is now very good`. I did some quick testing and it seems to be on a par with `ciso8601`:
On Python 3.10 I've got ~37,5s and ~3,5s without and with `ciso8601` installed, respectively. On Python 3.11 I've got ~2,5s and ~2,6s without and with `ciso8601` installed, respectively.

Because `ciso` is no dependency, but an extra, not all users (including me) installed it. With this PR these users will get a better out-of-the-box performance for Python 3.11+ users.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
