### PR TITLE
fix(write-api): accept 201 response to write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#652](https://github.com/influxdata/influxdb-client-python/pull/652): Refactor to `timezone` specific `datetime` helpers to avoid use deprecated functions
+1. [#663](https://github.com/influxdata/influxdb-client-python/pull/663): Accept HTTP 201 response to write request
 
 ## 1.44.0 [2024-06-24]
 

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -122,4 +122,4 @@ class WriteApiAsync(_BaseWriteApi):
                                                               precision=write_precision, async_req=False,
                                                               _return_http_data_only=False,
                                                               content_type="text/plain; charset=utf-8")
-        return response[1] == 204
+        return response[1] in (201, 204)


### PR DESCRIPTION
Helps internal issue https://github.com/influxdata/idpe/issues/18710

## Proposed Changes

InfluxDB v3 Serverless will soon return 201 or 204, in cases where InfluxDB v1 and v2 only return 204. This change anticipates this API change. Public docs will also be updated.

InfluxDB v3 Dedicated and Clustered already have this behavior, and it is already documented.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- n/a A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- n/a Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
  - I'm an employee.