### PR TITLE
fix: add py.typed to the package definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.46.0 [unreleased]
 
+### Bug Fixes
+1. [#667](https://github.com/influxdata/influxdb-client-python/pull/667): Missing `py.typed` in distribution package
+
 ### Examples:
 1. [#664](https://github.com/influxdata/influxdb-client-python/pull/664/): Multiprocessing example uses new source of data
 1. [#665](https://github.com/influxdata/influxdb-client-python/pull/665): Shows how to leverage header fields in errors returned on write.

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     extras_require={'extra': extra_requires, 'ciso': ciso_requires, 'async': async_requires, 'test': test_requires},
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=('tests*',)),
+    package_data={'influxdb_client': ['py.typed']},
     test_suite='tests',
     python_requires='>=3.7',
     include_package_data=True,


### PR DESCRIPTION
Closes #666

## Proposed Changes

Fixed adding py.typed into package.

Tested via:

```
mkdir typed
cd typed
python -m venv venv
. venv/bin/activate
python -m pip install git+https://github.com/influxdata/influxdb-client-python.git@typed-definition-setup.py
ls -l venv/lib/python3.11/site-packages/influxdb_client
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
