### PR TITLE
fix: add url object type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 1. [#667](https://github.com/influxdata/influxdb-client-python/pull/667): Missing `py.typed` in distribution package
+2. [#670](https://github.com/influxdata/influxdb-client-python/pull/670): Adding type validation to url attribute in client object
 
 ### Examples:
 1. [#664](https://github.com/influxdata/influxdb-client-python/pull/664/): Multiprocessing example uses new source of data

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -53,6 +53,8 @@ class _BaseClient(object):
         self.default_tags = default_tags
 
         self.conf = _Configuration()
+        if not isinstance(self.url, str):
+            raise ValueError('"url" attribute is not str instance')
         if self.url.endswith("/"):
             self.conf.host = self.url[:-1]
         else:


### PR DESCRIPTION
fix: added type validation to an attribute in client object

## Proposed Changes
It is possible to pass "None" by mistake to the InfluxDBClient object.
I propose to do a quick sanity check on it.

Traceback example:
client_obj = InfluxDBClient(url=url, token=token, org=org)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/influxdb_client.py", line 63, in __init__
    super().__init__(url=url, token=token, debug=debug, timeout=timeout, enable_gzip=enable_gzip, org=org,
  File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/_base.py", line 56, in __init__
    if self.url.endswith("/"):
       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
Exception ignored in: <function InfluxDBClient.__del__ at 0x7ff5627789a0>
Traceback (most recent call last):
  File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/influxdb_client.py", line 319, in __del__
    if self.api_client:
       ^^^^^^^^^^^^^^^
AttributeError: 'InfluxDBClient' object has no attribute 'api_client'

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
