### PR TITLE
fix: url attribute type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## 1.47.0 [unreleased]
 
+### Bug Fixes
+1. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
+
 ## 1.46.0 [2024-09-13]
 
 ### Bug Fixes
 1. [#667](https://github.com/influxdata/influxdb-client-python/pull/667): Missing `py.typed` in distribution package
-2. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
 
 ### Examples:
 1. [#664](https://github.com/influxdata/influxdb-client-python/pull/664/): Multiprocessing example uses new source of data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 1. [#667](https://github.com/influxdata/influxdb-client-python/pull/667): Missing `py.typed` in distribution package
+2. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
 
 ### Examples:
 1. [#664](https://github.com/influxdata/influxdb-client-python/pull/664/): Multiprocessing example uses new source of data

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -53,6 +53,8 @@ class _BaseClient(object):
         self.default_tags = default_tags
 
         self.conf = _Configuration()
+        if not isinstance(self.url, str):
+            raise ValueError('"url" attribute is not str instance')
         if self.url.endswith("/"):
             self.conf.host = self.url[:-1]
         else:

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -323,6 +323,35 @@ class InfluxDBClientTestIT(BaseTest):
         version = self.client.version()
         self.assertTrue(len(version) > 0)
 
+    def test_url_attribute(self):
+        # Wrong URL attribute
+        wrong_types = [
+            None,
+            True, False,
+            123, 123.5,
+            dict({"url" : "http://localhost:8086"}),
+            list(["http://localhost:8086"]),
+            tuple(("http://localhost:8086"))
+        ]
+        correct_types = [
+            "http://localhost:8086"
+        ]
+        for url_type in wrong_types:
+            try:
+                client_not_running = InfluxDBClient(url=url_type, token="my-token", debug=True)
+                status = True
+            except ValueError as e:
+                status = False
+            self.assertFalse(status)
+        for url_type in correct_types:
+            try:
+                client_not_running = InfluxDBClient(url=url_type, token="my-token", debug=True)
+                status = True
+            except ValueError as e:
+                status = False
+            self.assertTrue(status)
+
+
     def test_build(self):
         build = self.client.build()
         self.assertEqual('oss', build.lower())


### PR DESCRIPTION
fix: added type validation to an attribute in client object

## Proposed Changes

It is possible to pass "None" by mistake to the InfluxDBClient object.
I propose to do a quick sanity check on it.

Traceback example:
client_obj = InfluxDBClient(url=url, token=token, org=org)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/influxdb_client.py", line 63, in init
super().init(url=url, token=token, debug=debug, timeout=timeout, enable_gzip=enable_gzip, org=org,
File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/_base.py", line 56, in init
if self.url.endswith("/"):
^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
Exception ignored in: <function InfluxDBClient.del at 0x7ff5627789a0>
Traceback (most recent call last):
File "vitaly.chait/.local/lib/python3.12/site-packages/influxdb_client/client/influxdb_client.py", line 319, in del
if self.api_client:
^^^^^^^^^^^^^^^
AttributeError: 'InfluxDBClient' object has no attribute 'api_client'

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
