### PR TITLE
fix: async write prec where DEFAULT_PRECISION should not be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
+2. [#675](https://github.com/influxdata/influxdb-client-python/pull/675): Ensures WritePrecision in Point is preferred to `DEFAULT_PRECISION`
 
 ## 1.46.0 [2024-09-13]
 

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -118,11 +118,11 @@ class WriteApiAsync(_BaseWriteApi):
         self._serialize(record, write_precision, payloads, precision_from_point=True, **kwargs)
 
         futures = []
-        for payload in payloads.items():
+        for payload_precision, payload_line in payloads.items():
             futures.append(ensure_future
                            (self._write_service.post_write_async(org=org, bucket=bucket,
-                                                                 body=b'\n'.join(payload[1]),
-                                                                 precision=payload[0], async_req=False,
+                                                                 body=b'\n'.join(payload_line),
+                                                                 precision=payload_precision, async_req=False,
                                                                  _return_http_data_only=False,
                                                                  content_type="text/plain; charset=utf-8")))
 

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -119,15 +119,16 @@ class WriteApiAsync(_BaseWriteApi):
 
         futures = []
         for payload in payloads.items():
-            futures.append(ensure_future(self._write_service.post_write_async(org=org, bucket=bucket,
-                                                                              body=b'\n'.join(payload[1]),
-                                                                              precision=payload[0], async_req=False,
-                                                                              _return_http_data_only=False,
-                                                                              content_type="text/plain; charset=utf-8")))
+            futures.append(ensure_future
+                           (self._write_service.post_write_async(org=org, bucket=bucket,
+                                                                 body=b'\n'.join(payload[1]),
+                                                                 precision=payload[0], async_req=False,
+                                                                 _return_http_data_only=False,
+                                                                 content_type="text/plain; charset=utf-8")))
 
         results = await gather(*futures, return_exceptions=True)
         for result in results:
             if isinstance(result, Exception):
                 raise result
 
-        return False not in [re[1] in (201,204) for re in results]
+        return False not in [re[1] in (201, 204) for re in results]

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -1,5 +1,6 @@
 """Collect and async write time series data to InfluxDB Cloud or InfluxDB OSS."""
 import logging
+from asyncio import ensure_future, gather
 from collections import defaultdict
 from typing import Union, Iterable, NamedTuple
 
@@ -114,12 +115,19 @@ class WriteApiAsync(_BaseWriteApi):
         self._append_default_tags(record)
 
         payloads = defaultdict(list)
-        self._serialize(record, write_precision, payloads, precision_from_point=False, **kwargs)
+        self._serialize(record, write_precision, payloads, precision_from_point=True, **kwargs)
 
-        # joint list by \n
-        body = b'\n'.join(payloads[write_precision])
-        response = await self._write_service.post_write_async(org=org, bucket=bucket, body=body,
-                                                              precision=write_precision, async_req=False,
-                                                              _return_http_data_only=False,
-                                                              content_type="text/plain; charset=utf-8")
-        return response[1] in (201, 204)
+        futures = []
+        for payload in payloads.items():
+            futures.append(ensure_future(self._write_service.post_write_async(org=org, bucket=bucket,
+                                                                              body=b'\n'.join(payload[1]),
+                                                                              precision=payload[0], async_req=False,
+                                                                              _return_http_data_only=False,
+                                                                              content_type="text/plain; charset=utf-8")))
+
+        results = await gather(*futures, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                raise result
+
+        return False not in [re[1] in (201,204) for re in results]


### PR DESCRIPTION
Closes #669

## Proposed Changes

- set argument `precision_from_point` in internal `_serialize` method to `True`.
- detect `WritePrecision` key in resulting payload
- use the key to set `precision` argument in call to internal `_write_service.post_write_async`
- update `test_write_points_different_precision` to cover more current possible values 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
