### PR TITLE
fix: linting at flux_table.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## 1.47.0 [unreleased]
 
 ### Bug Fixes
-1. [#674](https://github.com/influxdata/influxdb-client-python/pull/674): Adding type linting to client.flux_table.FluxTable
-2. Removed duplicated  ```from pathlib import Path``` at setup.py (to pass 1 linting test)
-
-### Bug Fixes
-1. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
+1. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Add type validation to url attribute in client object
+1. [#674](https://github.com/influxdata/influxdb-client-python/pull/674): Add type linting to client.flux_table.FluxTable, remove duplicated `from pathlib import Path` at setup.py
 
 ## 1.46.0 [2024-09-13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.47.0 [unreleased]
 
 ### Bug Fixes
+1. [#674](https://github.com/influxdata/influxdb-client-python/pull/674): Adding type linting to client.flux_table.FluxTable
+2. Removed duplicated  ```from pathlib import Path``` at setup.py (to pass 1 linting test)
+
+### Bug Fixes
 1. [#672](https://github.com/influxdata/influxdb-client-python/pull/672): Adding type validation to url attribute in client object
 
 ## 1.46.0 [2024-09-13]

--- a/influxdb_client/client/flux_table.py
+++ b/influxdb_client/client/flux_table.py
@@ -46,8 +46,8 @@ class FluxTable(FluxStructure):
 
     def __init__(self) -> None:
         """Initialize defaults."""
-        self.columns = []
-        self.records = []
+        self.columns: List[FluxColumn] = []
+        self.records: List[FluxRecord] = []
 
     def get_group_key(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ async_requires = [
     'aiocsv>=1.2.2'
 ]
 
-from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 


### PR DESCRIPTION
Closes #674

## Proposed Changes

```python
class FluxTable(FluxStructure):
    def __init__(self) -> None:
        self.columns: List[FluxColumn] = [] #<<<<---- Added this typing
        self.records: List[FluxRecord] = []    #<<<<---- Added this typing
```

Testing found the following warnings:
1. duplicated import
```python
#setup.py
from pathlib import Path
from pathlib import Path #<<<<-------------deleted duplicated
```

## NOTE
There's still unrelated tests that are not passing
```make lint```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
