### PR TITLE
Implement flush in write_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 2. [#674](https://github.com/influxdata/influxdb-client-python/pull/674): Add type linting to client.flux_table.FluxTable, remove duplicated `from pathlib import Path` at setup.py
 3. [#675](https://github.com/influxdata/influxdb-client-python/pull/675): Ensures WritePrecision in Point is preferred to `DEFAULT_PRECISION`
 
+### Features
+
+1. [#678](https://github.com/influxdata/influxdb-client-python/pull/678): Implement flush method in `Write_api`
+
 ## 1.46.0 [2024-09-13]
 
 ### Bug Fixes

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -387,8 +387,8 @@ You can use native asynchronous version of the client:
 
     def flush(self):
         """Flush data."""
-        # TODO
-        pass
+        if self._subject:
+            self._subject.on_completed()
 
     def close(self):
         """Flush data and dispose a batching buffer."""
@@ -411,8 +411,8 @@ You can use native asynchronous version of the client:
 
     def __del__(self):
         """Close WriteApi."""
+        self.flush()
         if self._subject:
-            self._subject.on_completed()
             self._subject.dispose()
             self._subject = None
 


### PR DESCRIPTION
## Proposed Changes

write_api is send data when it close or delete on batching mode. but i want to reuse same object. so i implement flush function as simply call on_complete

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
