### PR TITLE
fix: catch CancelledError and TimeoutError and add note about timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.48.0 [unreleased]
 
+### Bug Fixes
+
+1. [#679](https://github.com/influxdata/influxdb-client-python/pull/679): Add note to caught errors about need to check client timeout.
+
 ## 1.47.0 [2024-10-22]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,13 @@ All async APIs are available via `influxdb_client.client.influxdb_client_async.I
 
 and also check to readiness of the InfluxDB via `/ping` endpoint:
 
+The `InfluxDBClientAsync` constructor accepts a number of __configuration properties__.  Most useful among these are:
+
+* `connection_pool_maxsize` - The total number of simultaneous connections. Defaults to `multiprocessing.cpu_count() * 5`.
+* `enable_gzip` - enable gzip compression during `write` and `query` calls.  Defaults to `false`.
+* `proxy` - URL of an HTTP proxy to be used.
+* `timeout` - The maximum number of milliseconds for handling HTTP requests from initial handshake to handling response data.  This is passed directly to the underlying transport library.  If large amounts of data are anticipated, for example from `query_api.query_stream(...)`, this should be increased to avoid `TimeoutError` or `CancelledError`.  Defaults to 10_000 ms.
+
 > ``` python
 > import asyncio
 >

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -1,6 +1,5 @@
 """Parsing response from InfluxDB to FluxStructures or DataFrame."""
 
-import asyncio
 import base64
 import codecs
 import csv as csv_parser
@@ -147,8 +146,10 @@ class FluxCsvParser(object):
                 df = self._prepare_data_frame()
                 if not self._is_profiler_table(metadata.table):
                     yield df
-        except (asyncio.exceptions.CancelledError, asyncio.TimeoutError) as ce:
-            ce.add_note("Stream cancelled during read.  Recommended: Check Influxdb client `timeout` setting.")
+        except BaseException as e:
+            e_type = type(e).__name__
+            if "CancelledError" in e_type or "TimeoutError" in e_type:
+                e.add_note("Stream cancelled during read.  Recommended: Check Influxdb client `timeout` setting.")
             raise
         finally:
             self._close()

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -1,6 +1,6 @@
 """Parsing response from InfluxDB to FluxStructures or DataFrame."""
 
-
+import asyncio
 import base64
 import codecs
 import csv as csv_parser
@@ -147,6 +147,9 @@ class FluxCsvParser(object):
                 df = self._prepare_data_frame()
                 if not self._is_profiler_table(metadata.table):
                     yield df
+        except (asyncio.exceptions.CancelledError, asyncio.TimeoutError) as ce:
+            ce.add_note("Stream cancelled during read.  Recommended: Check Influxdb client `timeout` setting.")
+            raise
         finally:
             self._close()
 


### PR DESCRIPTION
Closes #671

## Proposed Changes

in `flux_csv_parser` catch `CancelledError` and `TimeoutError` and add a note to check the client `timeout` setting. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
