### PR TITLE
write 2 points in example.py

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -14,7 +14,9 @@ with InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org",
     # write using point structure
     write_api.write(bucket="my-bucket", record=p)
 
-    line_protocol = p.to_line_protocol()
+    plp = Point("my_measurement").tag("location", "Athens").field("temperature", 35.3) \
+        .time(datetime.now(tz=timezone.utc))
+    line_protocol = plp.to_line_protocol()
     print(line_protocol)
 
     # write using line protocol string


### PR DESCRIPTION
Closes #

## Proposed Changes

Create and write 2 points instead of one in the example.py file.

Previously, the second write (with the line_protocol) erased the first write (with the Point structure) as timestamps are the same. Besides, the WritePrecision.MS made the line_protocol time conversion to somewhere in February 1970 (at time of writing), instead of current date & time.

So it is proposed here to write two distinct points to improve example understanding, and remove the WritePrecision.MS when writing with line_protocol, as is done in other examples, in order to write both points at the timestamp of execution.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] Rebased/mergeable
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)

