### PR TITLE
feat: move-setuptools-build-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.50.0 [unreleased]
 
+### Features
+
+1. [696](https://github.com/influxdata/influxdb-client-python/pull/696): Move "setuptools" package to build dependency.
+
 ## 1.49.0 [2025-05-22]
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=21.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ requires = [
     'reactivex >= 4.0.4',
     'certifi >= 14.05.14',
     'python_dateutil >= 2.5.3',
-    'setuptools >= 21.0.0',
     'urllib3 >= 1.26.0'
 ]
 

--- a/tests/test_Helpers.py
+++ b/tests/test_Helpers.py
@@ -56,5 +56,4 @@ class HelpersTest(BaseTest):
 
         with pytest.raises(InfluxDBError) as e:
             get_org_query_param("my-org", self.client, required_id=True)
-        assert "The client cannot find organization with name: 'my-org' to determine their ID. Are you using token " \
-               "with sufficient permission?" in f"{e.value} "
+        assert "The client cannot find organization with name: 'my-org' to determine their ID" in f"{e.value} "

--- a/tests/test_Helpers.py
+++ b/tests/test_Helpers.py
@@ -56,4 +56,5 @@ class HelpersTest(BaseTest):
 
         with pytest.raises(InfluxDBError) as e:
             get_org_query_param("my-org", self.client, required_id=True)
-        assert "The client cannot find organization with name: 'my-org' to determine their ID" in f"{e.value} "
+        assert "The client cannot find organization with name: 'my-org' to determine their ID. Are you using token " \
+               "with sufficient permission?" in f"{e.value} "


### PR DESCRIPTION
Close [695](https://github.com/influxdata/influxdb-client-python/issues/695)

## Proposed Changes

- Move the "setuptools" package to build dependency to accommodate new check from the homeassistant library

_ Before the fix
<img width="1408" alt="Screenshot 2025-06-01 at 09 11 22" src="https://github.com/user-attachments/assets/21edfc91-88a3-4044-a9f0-89dbe7e7e700" />

_ After the fix: I think the new error message means we have had solved the dependency issue, check out "home-assistant-core/script/hassfest/requirements.py" line 169. The new error message is for the homeassistant team
<img width="1406" alt="Screenshot 2025-06-01 at 09 17 20" src="https://github.com/user-attachments/assets/ab8d9c69-532a-40cf-a7a2-c04531b6470a" />

_ My steps to reproduce the issue:
 - Checkout [Home assistant core repo](https://github.com/home-assistant/core)
- Run "source venv/bin/activate"
 - Run "python3 -m script.gen_requirements_all && pip3.13 install -r requirements_all.txt --break-system-package"
 - Run "python3 -m script.hassfest --integration-path "home-assistant-core/homeassistant/components/influxdb" --requirement"

- My steps to fix 
 - Build influxdb-client-python with the latest change -> Upload to PyPi [Link](https://pypi.org/project/sonnh-influxdb-clientv2/1.50.0.dev0/). After that, replace the content of "homeassistant/components/influxdb/manifest.json" like this 
[manifest.json](https://github.com/user-attachments/files/20537598/manifest.json)

 - Run the same steps as when reproducing the issue again

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed