### PR TITLE
fix Pandas 2 FutureWarning: The behavior of array concatenation with empty entries is deprecated

### DIFF
--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -259,7 +259,7 @@ class FluxCsvParser(object):
             _temp_df = _temp_df.set_index(self._data_frame_index)
 
         # Append data
-        df = pd.concat([self._data_frame.astype(_temp_df.dtypes), _temp_df])
+        df = _temp_df if self._data_frame.empty else pd.concat([self._data_frame.astype(_temp_df.dtypes), _temp_df])
 
         if self._use_extension_dtypes:
             return df.convert_dtypes()


### PR DESCRIPTION
Closes #613

## Proposed Changes

avoid calling concat when df is empty

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `pytest tests` completes successfully
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
