### PR TITLE
fix: link formatting in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-1. [696](https://github.com/influxdata/influxdb-client-python/pull/696): Move "setuptools" package to build dependency.
+1. [#696](https://github.com/influxdata/influxdb-client-python/pull/696): Move "setuptools" package to build dependency.
 
 ## 1.49.0 [2025-05-22]
 


### PR DESCRIPTION
## Proposed Changes

This pull request makes a minor update to the `CHANGELOG.md` file, correcting the formatting of a pull request reference to use the `#` symbol for consistency with other entries.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
