### PR TITLE
README: remove lightweight

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Documentation status](https://readthedocs.org/projects/influxdb-client/badge/?version=stable)](https://influxdb-client.readthedocs.io/en/stable/)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://www.influxdata.com/slack)
 
-This repository contains the Python client library for use with InfluxDB 2.x and Flux. InfluxDB 3.x users should instead use the lightweight [v3 client library](https://github.com/InfluxCommunity/influxdb3-python).
+This repository contains the Python client library for use with InfluxDB 2.x and Flux. InfluxDB 3.x users should instead use the [v3 client library](https://github.com/InfluxCommunity/influxdb3-python).
 InfluxDB 1.x users should use the [v1 client library](https://github.com/influxdata/influxdb-python).
 
 For ease of migration and a consistent query and write experience, v2 users should consider using InfluxQL and the [v1 client library](https://github.com/influxdata/influxdb-python).


### PR DESCRIPTION
```
  Downloading https://www.piwheels.org/simple/influxdb-client/influxdb_client-1.50.0-py3-none-any.whl (746 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 746.4/746.4 kB 1.3 MB/s eta 0:00:00

Collecting influxdb3-python
  Downloading influxdb3_python-0.17.0-py3-none-any.whl.metadata (10 kB)
Requirement already satisfied: reactivex>=4.0.4 in ./lib/python3.13/site-packages (from influxdb3-python) (4.1.0)
Requirement already satisfied: certifi>=14.05.14 in ./lib/python3.13/site-packages (from influxdb3-python) (2026.1.4)
Requirement already satisfied: python_dateutil>=2.5.3 in ./lib/python3.13/site-packages (from influxdb3-python) (2.9.0.post0)
Requirement already satisfied: urllib3>=1.26.0 in ./lib/python3.13/site-packages (from influxdb3-python) (2.6.3)
Collecting pyarrow>=8.0.0 (from influxdb3-python)
  Downloading pyarrow-23.0.0-cp313-cp313-manylinux_2_28_aarch64.whl.metadata (3.0 kB)
Requirement already satisfied: six>=1.5 in ./lib/python3.13/site-packages (from python_dateutil>=2.5.3->influxdb3-python) (1.17.0)
Requirement already satisfied: typing-extensions<5.0.0,>=4.1.1 in ./lib/python3.13/site-packages (from reactivex>=4.0.4->influxdb3-python) (4.15.0)
Downloading influxdb3_python-0.17.0-py3-none-any.whl (94 kB)
Downloading pyarrow-23.0.0-cp313-cp313-manylinux_2_28_aarch64.whl (44.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44.4/44.4 MB 1.2 MB/s eta 0:00:00
Installing collected packages: pyarrow, influxdb3-python
```