### PR TITLE
test: fix parser and redirect test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,13 +1097,20 @@ with InfluxDBClient(url="http://localhost:8086",
 
 If your proxy notify the client with permanent redirect (`HTTP 301`) to **different host**. The client removes `Authorization` header, because otherwise the contents of `Authorization` is sent to third parties which is a security vulnerability.
 
-You can change this behaviour by:
+You can change this behavior by doing this in older urllib3 versions:
 
 ``` python
 from urllib3 import Retry
 Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset()
 Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
 ```
+In the newer urllib3 versions, try to use this:
+
+``` python
+retries = Retry(redirect=1, remove_headers_on_redirect=[])
+self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", org="my-org", retries=retries)
+```
+
 <!-- marker-proxy-end -->
 
 ### Delete data

--- a/README.md
+++ b/README.md
@@ -1097,14 +1097,16 @@ with InfluxDBClient(url="http://localhost:8086",
 
 If your proxy notify the client with permanent redirect (`HTTP 301`) to **different host**. The client removes `Authorization` header, because otherwise the contents of `Authorization` is sent to third parties which is a security vulnerability.
 
-You can change this behavior by doing this in older urllib3 versions:
+You can change this behavior by doing this in older urllib3 versions < 2.5.0 :
 
 ``` python
 from urllib3 import Retry
 Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset()
 Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
 ```
-In the newer urllib3 versions, try to use this:
+
+In the newer urllib3 versions >= 2.5.0, try to use this for redirect requests and stop urllib3 from 
+removing the `Authorization` header: :
 
 ``` python
 retries = Retry(redirect=1, remove_headers_on_redirect=[])

--- a/influxdb_client/client/flux_csv_parser.py
+++ b/influxdb_client/client/flux_csv_parser.py
@@ -251,6 +251,16 @@ class FluxCsvParser(object):
 
         # We have to create temporary DataFrame because we want to preserve default column values
         _temp_df = pd.DataFrame(self._data_frame_values)
+        # This is for backward compatibles reason
+        # In newer Pandas versions 'string' type will be 'str', in older versions 'string' type will be 'object'
+        # In newer Pandas versions 'time' will be 'datetime64[us, UTC]', in older versions 'time'
+        # will be 'datetime64[ns, UTC]'
+        for column in _temp_df.columns:
+            if _temp_df[column].dtype.name == 'str':
+                _temp_df[column] = _temp_df[column].astype(object)
+            if _temp_df[column].dtype.name == 'datetime64[us, UTC]':
+                _temp_df[column] = _temp_df[column].astype('datetime64[ns, UTC]')
+
         self._data_frame_values = []
 
         # Custom DataFrame index

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -532,7 +532,8 @@ class WriteApiTestMock(BaseTest):
         Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
         self.influxdb_client.close()
 
-        self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", org="my-org")
+        retries = Retry(redirect=1, remove_headers_on_redirect=[])
+        self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", org="my-org", retries=retries)
 
         httpretty.register_uri(httpretty.POST, uri="http://localhost2/api/v2/write", status=204)
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=301,

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -528,8 +528,6 @@ class WriteApiTestMock(BaseTest):
 
     def test_redirect(self):
         from urllib3 import Retry
-        Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset()
-        Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
         self.influxdb_client.close()
 
         retries = Retry(redirect=1, remove_headers_on_redirect=[])
@@ -547,9 +545,6 @@ class WriteApiTestMock(BaseTest):
         self.assertEqual(2, len(requests))
         self.assertEqual('Token my-token', requests[0].headers['Authorization'])
         self.assertEqual('Token my-token', requests[1].headers['Authorization'])
-
-        from urllib3 import Retry
-        Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
 
     def test_named_tuple(self):
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -528,8 +528,12 @@ class WriteApiTestMock(BaseTest):
 
     def test_redirect(self):
         from urllib3 import Retry
+        Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT = frozenset()
+        Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
         self.influxdb_client.close()
 
+        # In the newer urllib3 versions we need to set `redirect` and `remove_headers_on_redirect=[]` to
+        # make it re-direct POST requests and stop it from remove the `Authorization` header.
         retries = Retry(redirect=1, remove_headers_on_redirect=[])
         self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", org="my-org", retries=retries)
 
@@ -545,6 +549,9 @@ class WriteApiTestMock(BaseTest):
         self.assertEqual(2, len(requests))
         self.assertEqual('Token my-token', requests[0].headers['Authorization'])
         self.assertEqual('Token my-token', requests[1].headers['Authorization'])
+
+        from urllib3 import Retry
+        Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
 
     def test_named_tuple(self):
         httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)

--- a/tests/test_WriteApi.py
+++ b/tests/test_WriteApi.py
@@ -532,7 +532,7 @@ class WriteApiTestMock(BaseTest):
         Retry.DEFAULT.remove_headers_on_redirect = Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT
         self.influxdb_client.close()
 
-        # In the newer urllib3 versions we need to set `redirect` and `remove_headers_on_redirect=[]` to
+        # In the newer urllib3 versions >= 2.5.0 we need to set `redirect` and `remove_headers_on_redirect=[]` to
         # make it re-direct POST requests and stop it from remove the `Authorization` header.
         retries = Retry(redirect=1, remove_headers_on_redirect=[])
         self.influxdb_client = InfluxDBClient(url="http://localhost", token="my-token", org="my-org", retries=retries)


### PR DESCRIPTION
Closes #

## Proposed Changes

- New "pandas" versions return different data types than old ones.
   In newer Pandas versions "string" type will be "str", in older versions "string" type will be "object"
   In newer Pandas versions 'time' will be "datetime64[us, UTC]", in older versions "time" will be "datetime64[ns, UTC]"
⇒ Add code to convert "str" back to "object", "datetime64[us, UTC]" back to "datetime64[ns, UTC]"
- New "urllib3" doesn't auto-redirect POST request anymore.
⇒ Manually add `Retry(redirect=1, remove_headers_on_redirect=[])` to make it redirect and stop it from removes "Authorization" header.  

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
