### PR TITLE
fix: stop default_tags from one client leaking into other clients' WriteApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#706](https://github.com/influxdata/influxdb-client-python/pull/706): Use logger instead logging.
+1. [#686](https://github.com/influxdata/influxdb-client-python/issues/686): Stop `default_tags` from one client leaking into other clients' `WriteApi` (shared mutable default `PointSettings`).
 
 ## 1.50.0 [2026-01-23]
 

--- a/influxdb_client/client/_base.py
+++ b/influxdb_client/client/_base.py
@@ -441,8 +441,9 @@ class _BaseQueryApi(object):
 
 class _BaseWriteApi(object):
     def __init__(self, influxdb_client, point_settings=None):
+        from influxdb_client.client.write_api import PointSettings
         self._influxdb_client = influxdb_client
-        self._point_settings = point_settings
+        self._point_settings = point_settings if point_settings is not None else PointSettings()
         self._write_service = WriteService(influxdb_client.api_client)
         if influxdb_client.default_tags:
             for key, value in influxdb_client.default_tags.items():

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -16,7 +16,7 @@ from influxdb_client.client.organizations_api import OrganizationsApi
 from influxdb_client.client.query_api import QueryApi, QueryOptions
 from influxdb_client.client.tasks_api import TasksApi
 from influxdb_client.client.users_api import UsersApi
-from influxdb_client.client.write_api import WriteApi, WriteOptions, PointSettings
+from influxdb_client.client.write_api import WriteApi, WriteOptions
 
 logger = logging.getLogger('influxdb_client.client.influxdb_client')
 
@@ -210,7 +210,7 @@ class InfluxDBClient(_BaseClient):
         """
         return InfluxDBClient._from_env_properties(debug=debug, enable_gzip=enable_gzip, **kwargs)
 
-    def write_api(self, write_options=WriteOptions(), point_settings=PointSettings(), **kwargs) -> WriteApi:
+    def write_api(self, write_options=WriteOptions(), point_settings=None, **kwargs) -> WriteApi:
         """
         Create Write API instance.
 

--- a/influxdb_client/client/influxdb_client_async.py
+++ b/influxdb_client/client/influxdb_client_async.py
@@ -7,7 +7,6 @@ from influxdb_client.client._base import _BaseClient
 from influxdb_client.client.delete_api_async import DeleteApiAsync
 from influxdb_client.client.query_api import QueryOptions
 from influxdb_client.client.query_api_async import QueryApiAsync
-from influxdb_client.client.write_api import PointSettings
 from influxdb_client.client.write_api_async import WriteApiAsync
 
 logger = logging.getLogger('influxdb_client.client.influxdb_client_async')
@@ -273,7 +272,7 @@ class InfluxDBClientAsync(_BaseClient):
         """
         return QueryApiAsync(self, query_options)
 
-    def write_api(self, point_settings=PointSettings()) -> WriteApiAsync:
+    def write_api(self, point_settings=None) -> WriteApiAsync:
         """
         Create an asynchronous Write API instance.
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -213,7 +213,7 @@ class WriteApi(_BaseWriteApi):
     def __init__(self,
                  influxdb_client,
                  write_options: WriteOptions = WriteOptions(),
-                 point_settings: PointSettings = PointSettings(),
+                 point_settings: PointSettings = None,
                  **kwargs) -> None:
         """
         Initialize defaults.

--- a/influxdb_client/client/write_api_async.py
+++ b/influxdb_client/client/write_api_async.py
@@ -31,7 +31,7 @@ class WriteApiAsync(_BaseWriteApi):
                 write_api = client.write_api()
     """
 
-    def __init__(self, influxdb_client, point_settings: PointSettings = PointSettings()) -> None:
+    def __init__(self, influxdb_client, point_settings: PointSettings = None) -> None:
         """
         Initialize defaults.
 

--- a/tests/test_InfluxDBClient.py
+++ b/tests/test_InfluxDBClient.py
@@ -32,6 +32,25 @@ class InfluxDBClientTest(unittest.TestCase):
         self.client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
         self.assertIsNotNone(self.client.api_client.configuration.connection_pool_maxsize)
 
+    def test_default_tags_not_shared_between_clients(self):
+        # https://github.com/influxdata/influxdb-client-python/issues/686
+        # default_tags from one client must not leak into another client's WriteApi.
+        self.client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
+        write_plain_before = self.client.write_api(write_options=SYNCHRONOUS)
+
+        client_tagged = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org",
+                                       default_tags={"id": "client-tagged"})
+        client_tagged.write_api(write_options=SYNCHRONOUS)
+
+        write_plain_after = self.client.write_api(write_options=SYNCHRONOUS)
+
+        try:
+            self.assertEqual({}, write_plain_before._point_settings.defaultTags)
+            self.assertEqual({}, write_plain_after._point_settings.defaultTags)
+            self.assertIsNot(write_plain_before._point_settings, write_plain_after._point_settings)
+        finally:
+            client_tagged.close()
+
     def test_TrailingSlashInUrl(self):
         self.client = InfluxDBClient(url="http://localhost:8086", token="my-token", org="my-org")
         self.assertEqual('http://localhost:8086', self.client.api_client.configuration.host)


### PR DESCRIPTION
Closes #686

## Proposed Changes

The write_api factories and the WriteApi/WriteApiAsync constructors defaulted point_settings to PointSettings(). Mutable default, so the same instance is shared across calls that omit it, and _BaseWriteApi.__init__ mutates it in place when the client has default_tags. So one client's default_tags leak into other clients' write APIs, even ones that set none. Same thing on the async path.

Did what the issue suggested: default the four point_settings args to None and create a fresh PointSettings in _BaseWriteApi.__init__ when it's None. Also dropped the now-unused PointSettings imports.

Added a regression test (plain client, then a client with default_tags, then reuse the plain client and check its tags are still empty). Fails on main, passes with the fix. flake8 clean.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] pytest tests completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
