### PR TITLE
chore: fix aioresponses support and update codecoverage gpg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x ./codecov

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requires = [
     'pytest-timeout>=2.1.0',
     'httpretty==1.0.5',
     'psutil>=5.6.3',
-    'aioresponses>=0.7.3',
+    'aioresponses==0.7.3',
     'sphinx==1.8.5',
     'sphinx_rtd_theme',
     'jinja2>=3.1.4'

--- a/tests/test_InfluxDBClientAsync.py
+++ b/tests/test_InfluxDBClientAsync.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+
 import dateutil.parser
 import logging
 import math
@@ -12,7 +14,10 @@ from io import StringIO
 import pandas
 import pytest
 import warnings
-from aioresponses import aioresponses
+
+if sys.version_info < (3, 10):
+    from aioresponses import aioresponses
+
 
 from influxdb_client import Point, WritePrecision, BucketsService, OrganizationsService, Organizations
 from influxdb_client.client.exceptions import InfluxDBError
@@ -429,13 +434,15 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
                                           debug=True)
         await self.client.query_api().query("buckets()", "my-org")
 
-    @async_test
-    @aioresponses()
-    async def test_init_without_token(self, mocked):
-        mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body='')
-        await self.client.close()
-        self.client = InfluxDBClientAsync("http://localhost")
-        await self.client.query_api().query("buckets()", "my-org")
+
+    if sys.version_info < (3, 10):
+        @async_test
+        @aioresponses()
+        async def test_init_without_token(self, mocked):
+            mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body='')
+            await self.client.close()
+            self.client = InfluxDBClientAsync("http://localhost")
+            await self.client.query_api().query("buckets()", "my-org")
 
     @async_test
     async def test_redacted_auth_header(self):
@@ -465,12 +472,13 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         results = await buckets_service.get_buckets_async()
         self.assertIn("my-bucket", list(map(lambda bucket: bucket.name, results.buckets)))
 
-    @async_test
-    @aioresponses()
-    async def test_parse_csv_with_new_lines_in_column(self, mocked):
-        await self.client.close()
-        self.client = InfluxDBClientAsync("http://localhost")
-        mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body='''#datatype,string,long,dateTime:RFC3339
+    if sys.version_info < (3, 10):
+        @async_test
+        @aioresponses()
+        async def test_parse_csv_with_new_lines_in_column(self, mocked):
+            await self.client.close()
+            self.client = InfluxDBClientAsync("http://localhost")
+            mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body='''#datatype,string,long,dateTime:RFC3339
 #group,false,false,false
 #default,_result,,
 ,result,table,_time
@@ -499,13 +507,13 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
 ,,1,profiler/operator,*universe.schemaMutationTransformation,keep2,4,1875,42042,64209,16052.25
 ,,1,profiler/operator,*universe.limitTransformation,limit3,3,1333,38750,47874,15958''')
 
-        records = []
-        await self.client\
-            .query_api(QueryOptions(profilers=["operator", "query"],
+            records = []
+            await self.client\
+                .query_api(QueryOptions(profilers=["operator", "query"],
                                     profiler_callback=lambda record: records.append(record))) \
-            .query("buckets()", "my-org")
+                .query("buckets()", "my-org")
 
-        self.assertEqual(4, len(records))
+            self.assertEqual(4, len(records))
 
     @async_test
     async def test_query_exception_propagation(self):
@@ -534,24 +542,25 @@ class InfluxDBClientAsyncTest(unittest.TestCase):
         self.assertTrue(re.compile("^v.*").match(headers.get("X-Influxdb-Version")))
         self.assertEqual("OSS", headers.get("X-Influxdb-Build"))
 
-    @async_test
-    @aioresponses()
-    async def test_parse_utf8_two_bytes_character(self, mocked):
-        await self.client.close()
-        self.client = InfluxDBClientAsync("http://localhost")
+    if sys.version_info < (3, 10):
+        @async_test
+        @aioresponses()
+        async def test_parse_utf8_two_bytes_character(self, mocked):
+            await self.client.close()
+            self.client = InfluxDBClientAsync("http://localhost")
 
-        body = '''#group,false,false,false,false,true,true,true
+            body = '''#group,false,false,false,false,true,true,true
 #datatype,string,long,dateTime:RFC3339,string,string,string,string
 #default,_result,,,,,,
 ,result,table,_time,_value,_field,_measurement,type
 '''
-        for i in range(1000):
-            body += f",,0,2022-10-13T12:28:31.{i}Z,ÂÂÂ,value,async,error\n"
+            for i in range(1000):
+                body += f",,0,2022-10-13T12:28:31.{i}Z,ÂÂÂ,value,async,error\n"
 
-        mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body=body)
+            mocked.post('http://localhost/api/v2/query?org=my-org', status=200, body=body)
 
-        data_frame = await self.client.query_api().query_data_frame("from()", "my-org")
-        self.assertEqual(1000, len(data_frame))
+            data_frame = await self.client.query_api().query_data_frame("from()", "my-org")
+            self.assertEqual(1000, len(data_frame))
 
     @async_test
     async def test_management_apis(self):


### PR DESCRIPTION
## Proposed Changes

Note that this client library is currently in maintenance mode only, so maintenance time is a factor in implementing these changes.  There are no plans to remove support for older python versions, nor to make newer python versions a standard reference point.   

__aioresponses__

The most [recent release](https://pypi.org/project/aioresponses/0.7.9/) of the `aioresponses` library presents a couple of problems.
   1. It no longer supports Python versions older than 3.10
   2. It requires support of a newer version of `aiohttp`, the absence of which leads to compilation problems, such as mismatched constructor signatures for `ClientResponse`. (`aiohttp` also dropped support for python 3.7 and older a few years ago).

solution:

1. fix aioresponses to the legacy 0.7.3 release
2. conditionally include aioresponses and tests leveraging this library in async tests.
   1. this should fix nightly builds
   2. the marked async tests should still be run at least in earlier python versions.
   3. it allows test suites for newer python versions to complete, albeit without the three tests in question. 

__codecoverage__

Endpoints for gpg data have changed. These have been updated. 


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated. N.A. 
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate N.A.
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
