### PR TITLE
fix: replace invalid tuple type annotations with typing.Tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#706](https://github.com/influxdata/influxdb-client-python/pull/706): Use logger instead logging.
+1. [#540](https://github.com/influxdata/influxdb-client-python/issues/540): Replace invalid tuple type annotations `(str, str, str)` with `Tuple[str, str, str]` in batching callbacks, examples and docs.
 1. [#686](https://github.com/influxdata/influxdb-client-python/issues/686): Stop `default_tags` from one client leaking into other clients' `WriteApi` (shared mutable default `PointSettings`).
 1. [#681](https://github.com/influxdata/influxdb-client-python/issues/681): Accept numeric zero for `RangeThreshold.min`/`max` and greater/lesser `value` (identity checks vs `None`, not truthiness); cover create-check serialization.
 

--- a/README.md
+++ b/README.md
@@ -1183,19 +1183,21 @@ The only exception is **batching** `WriteAPI` (for more info see [Batching](#bat
 This is because this API runs in the `background` in a `separate` thread and isn't possible to directly return underlying exceptions.
 
 ``` python
+from typing import Tuple
+
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.exceptions import InfluxDBError
 
 
 class BatchingCallback(object):
 
-    def success(self, conf: (str, str, str), data: str):
+    def success(self, conf: Tuple[str, str, str], data: str):
         print(f"Written batch: {conf}, data: {data}")
 
-    def error(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def error(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         print(f"Cannot write batch: {conf}, data: {data} due: {exception}")
 
-    def retry(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def retry(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         print(f"Retryable error occurs for batch: {conf}, data: {data} retry: {exception}")
 
 

--- a/examples/http_error_handling.py
+++ b/examples/http_error_handling.py
@@ -11,7 +11,7 @@ To test against cloud set the following environment variables:
 """
 import asyncio
 import os
-from typing import MutableMapping
+from typing import MutableMapping, Tuple
 
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.exceptions import InfluxDBError
@@ -47,14 +47,14 @@ class Config(object):
 # To encapsulate functions used in batch writing
 class BatchCB(object):
 
-    def success(self, conf: (str, str, str), data: str):
+    def success(self, conf: Tuple[str, str, str], data: str):
         print(f"Write success: {conf}, data: {data}")
 
-    def error(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def error(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         print(f"\nBatch -> Write failed: {conf}, data: {data}, error: {exception.message}")
         report_headers(exception.headers)
 
-    def retry(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def retry(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         print(f"Write failed but retryable: {conf}, data: {data}, error: {exception}")
 
 

--- a/examples/write_api_callbacks.py
+++ b/examples/write_api_callbacks.py
@@ -2,6 +2,8 @@
 How to use WriteApi's callbacks to notify about state of background batches.
 """
 
+from typing import Tuple
+
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.exceptions import InfluxDBError
 
@@ -22,15 +24,15 @@ points = [Point("my-temperature").tag("location", "Prague").field("temperature",
 
 class BatchingCallback(object):
 
-    def success(self, conf: (str, str, str), data: str):
+    def success(self, conf: Tuple[str, str, str], data: str):
         """Successfully writen batch."""
         print(f"Written batch: {conf}, data: {data}")
 
-    def error(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def error(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         """Unsuccessfully writen batch."""
         print(f"Cannot write batch: {conf}, data: {data} due: {exception}")
 
-    def retry(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+    def retry(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
         """Retryable error."""
         print(f"Retryable error occurs for batch: {conf}, data: {data} retry: {exception}")
 

--- a/influxdb_client/client/influxdb_client.py
+++ b/influxdb_client/client/influxdb_client.py
@@ -240,19 +240,21 @@ class InfluxDBClient(_BaseClient):
 
         .. code-block:: python
 
+            from typing import Tuple
+
             from influxdb_client import InfluxDBClient
             from influxdb_client.client.exceptions import InfluxDBError
 
 
             class BatchingCallback(object):
 
-                def success(self, conf: (str, str, str), data: str):
+                def success(self, conf: Tuple[str, str, str], data: str):
                     print(f"Written batch: {conf}, data: {data}")
 
-                def error(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+                def error(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
                     print(f"Cannot write batch: {conf}, data: {data} due: {exception}")
 
-                def retry(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+                def retry(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
                     print(f"Retryable error occurs for batch: {conf}, data: {data} retry: {exception}")
 
 

--- a/influxdb_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client/client/util/multiprocessing_helper.py
@@ -6,6 +6,7 @@ For more information how the multiprocessing works see Python's
 """
 import logging
 import multiprocessing
+from typing import Tuple
 
 from influxdb_client import InfluxDBClient, WriteOptions
 from influxdb_client.client.exceptions import InfluxDBError
@@ -13,17 +14,17 @@ from influxdb_client.client.exceptions import InfluxDBError
 logger = logging.getLogger('influxdb_client.client.util.multiprocessing_helper')
 
 
-def _success_callback(conf: (str, str, str), data: str):
+def _success_callback(conf: Tuple[str, str, str], data: str):
     """Successfully writen batch."""
     logger.debug(f"Written batch: {conf}, data: {data}")
 
 
-def _error_callback(conf: (str, str, str), data: str, exception: InfluxDBError):
+def _error_callback(conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
     """Unsuccessfully writen batch."""
     logger.debug(f"Cannot write batch: {conf}, data: {data} due: {exception}")
 
 
-def _retry_callback(conf: (str, str, str), data: str, exception: InfluxDBError):
+def _retry_callback(conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
     """Retryable error."""
     logger.debug(f"Retryable error occurs for batch: {conf}, data: {data} retry: {exception}")
 
@@ -81,6 +82,8 @@ class MultiprocessingWriter(multiprocessing.Process):
     How to handle batch events:
         .. code-block:: python
 
+            from typing import Tuple
+
             from influxdb_client import WriteOptions
             from influxdb_client.client.exceptions import InfluxDBError
             from influxdb_client.client.util.multiprocessing_helper import MultiprocessingWriter
@@ -88,13 +91,13 @@ class MultiprocessingWriter(multiprocessing.Process):
 
             class BatchingCallback(object):
 
-                def success(self, conf: (str, str, str), data: str):
+                def success(self, conf: Tuple[str, str, str], data: str):
                     print(f"Written batch: {conf}, data: {data}")
 
-                def error(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+                def error(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
                     print(f"Cannot write batch: {conf}, data: {data} due: {exception}")
 
-                def retry(self, conf: (str, str, str), data: str, exception: InfluxDBError):
+                def retry(self, conf: Tuple[str, str, str], data: str, exception: InfluxDBError):
                     print(f"Retryable error occurs for batch: {conf}, data: {data} retry: {exception}")
 
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from enum import Enum
 from random import random
 from time import sleep
-from typing import Union, Any, Iterable, NamedTuple
+from typing import Union, Any, Iterable, NamedTuple, Tuple
 
 import reactivex as rx
 from reactivex import operators as ops, Observable
@@ -171,7 +171,7 @@ class _BatchItem(object):
         self.size = size
         pass
 
-    def to_key_tuple(self) -> (str, str, str):
+    def to_key_tuple(self) -> Tuple[str, str, str]:
         return self.key.bucket, self.key.org, self.key.precision
 
     def __str__(self) -> str:

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -6,6 +6,7 @@ import sys
 import time
 import unittest
 from collections import namedtuple
+from typing import Tuple
 
 import httpretty
 import pytest
@@ -582,7 +583,7 @@ class BatchingWriteTest(unittest.TestCase):
                 self.conf = None
                 self.data = None
 
-            def __call__(self, conf: (str, str, str), data: str):
+            def __call__(self, conf: Tuple[str, str, str], data: str):
                 self.conf = conf
                 self.data = data
 
@@ -617,7 +618,7 @@ class BatchingWriteTest(unittest.TestCase):
                 self.data = None
                 self.error = None
 
-            def __call__(self, conf: (str, str, str), data: str, error: InfluxDBError):
+            def __call__(self, conf: Tuple[str, str, str], data: str, error: InfluxDBError):
                 self.conf = conf
                 self.data = data
                 self.error = error
@@ -657,7 +658,7 @@ class BatchingWriteTest(unittest.TestCase):
                 self.data = None
                 self.error = None
 
-            def __call__(self, conf: (str, str, str), data: str, error: InfluxDBError):
+            def __call__(self, conf: Tuple[str, str, str], data: str, error: InfluxDBError):
                 self.conf = conf
                 self.data = data
                 self.error = error
@@ -704,7 +705,7 @@ class BatchingWriteTest(unittest.TestCase):
                 self.data = None
                 self.error = None
 
-            def __call__(self, conf: (str, str, str), data: str, error: InfluxDBError):
+            def __call__(self, conf: Tuple[str, str, str], data: str, error: InfluxDBError):
                 self.count += 1
                 self.conf = conf
                 self.data = data


### PR DESCRIPTION
Closes #540

## Proposed Changes

_Briefly describe your proposed changes:_

The batching callback signatures annotate `conf` as `(str, str, str)`. A tuple of
types is not a valid type annotation, so any code copy-pasted from the README
fails type checking:

```
example.py:7: error: Syntax error in type annotation  [syntax]
example.py:7: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
```

This replaces the pattern with `Tuple[str, str, str]` in the 23 places it
appears:

- `influxdb_client/client/write_api.py` — the `_BatchItem.to_key_tuple()` return
  annotation, which is the value actually passed to the callbacks
  (`bucket, org, precision`)
- `influxdb_client/client/util/multiprocessing_helper.py` — the
  `_success_callback` / `_error_callback` / `_retry_callback` signatures
- `influxdb_client/client/influxdb_client.py` and `multiprocessing_helper.py`
  docstring examples
- `examples/write_api_callbacks.py`, `examples/http_error_handling.py`
- `tests/test_WriteApiBatching.py`
- `README.md`

`typing.Tuple` is used rather than the PEP 585 builtin `tuple[...]` because
`setup.py` still declares `python_requires='>=3.7'`. The copy-pasteable examples
also gained the matching `from typing import Tuple` import so they remain
runnable as-is, which was the original point of the issue.

This is annotation-only — no runtime behaviour changes. Verified:

- `mypy` on the README snippet: 3 errors before, clean after
- `flake8 setup.py influxdb_client/` reports the same 2 pre-existing E721
  warnings in generated `_sync`/`_async` code as on `master`, and nothing new
- `pytest tests/test_WriteApiBatching.py` — 24 passed

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
