### PR TITLE
fix: implement WriteApi.flush() for batching mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#706](https://github.com/influxdata/influxdb-client-python/pull/706): Use logger instead logging.
 1. [#686](https://github.com/influxdata/influxdb-client-python/issues/686): Stop `default_tags` from one client leaking into other clients' `WriteApi` (shared mutable default `PointSettings`).
+1. [#697](https://github.com/influxdata/influxdb-client-python/issues/697): Implement `WriteApi.flush()` to force pending batch writes without disposing the API (mirrors C#/Java batch writer).
 
 ## 1.50.0 [2026-01-23]
 

--- a/influxdb_client/client/write_api.py
+++ b/influxdb_client/client/write_api.py
@@ -255,13 +255,23 @@ class WriteApi(_BaseWriteApi):
         if self._write_options.write_type is WriteType.batching:
             # Define Subject that listen incoming data and produces writes into InfluxDB
             self._subject = Subject()
+            # Flush subject forces the current batch window to close (mirrors Java/C# clients)
+            self._flush_subject = Subject()
 
             self._window_scheduler = ThreadPoolScheduler(1)
             self._disposable = self._subject.pipe(
-                # Split incoming data to windows by batch_size or flush_interval
-                ops.window_with_time_or_count(count=write_options.batch_size,
-                                              timespan=timedelta(milliseconds=write_options.flush_interval),
-                                              scheduler=self._window_scheduler),
+                # Split incoming data to windows by batch_size, flush_interval, or explicit flush().
+                # Window boundaries are the merge of time/count windows and the flush subject —
+                # same approach as the C# WriteApi batch writer.
+                ops.publish(lambda connected: connected.pipe(
+                    ops.window(
+                        rx.merge(
+                            connected.pipe(
+                                ops.window_with_time_or_count(
+                                    count=write_options.batch_size,
+                                    timespan=timedelta(milliseconds=write_options.flush_interval),
+                                    scheduler=self._window_scheduler)),
+                            self._flush_subject)))),
                 # Map  window into groups defined by 'organization', 'bucket' and 'precision'
                 ops.flat_map(lambda window: window.pipe(
                     # Group window by 'organization', 'bucket' and 'precision'
@@ -279,6 +289,7 @@ class WriteApi(_BaseWriteApi):
 
         else:
             self._subject = None
+            self._flush_subject = None
             self._disposable = None
 
         if self._write_options.write_type is WriteType.asynchronous:
@@ -386,9 +397,17 @@ You can use native asynchronous version of the client:
         return results
 
     def flush(self):
-        """Flush data."""
-        # TODO
-        pass
+        """
+        Flush data.
+
+        Forces the client to flush all pending writes from the batching buffer to InfluxDB
+        via HTTP without waiting for ``batch_size`` or ``flush_interval``. The ``WriteApi``
+        remains usable after ``flush()`` (unlike ``close()``).
+
+        Has no effect when batching is not enabled (synchronous / asynchronous write type).
+        """
+        if self._flush_subject is not None and not self._flush_subject.is_disposed:
+            self._flush_subject.on_next(None)
 
     def close(self):
         """Flush data and dispose a batching buffer."""
@@ -441,6 +460,11 @@ You can use native asynchronous version of the client:
                         max_wait_time
                     )
                     break
+
+        if self._flush_subject:
+            self._flush_subject.on_completed()
+            self._flush_subject.dispose()
+            self._flush_subject = None
 
         if self._window_scheduler:
             self._window_scheduler.executor.shutdown(wait=False)
@@ -570,6 +594,7 @@ You can use native asynchronous version of the client:
         state = self.__dict__.copy()
         # Remove rx
         del state['_subject']
+        del state['_flush_subject']
         del state['_disposable']
         del state['_window_scheduler']
         del state['_write_service']

--- a/tests/test_WriteApiBatching.py
+++ b/tests/test_WriteApiBatching.py
@@ -736,6 +736,72 @@ class BatchingWriteTest(unittest.TestCase):
         self.assertIsInstance(callback.error, InfluxDBError)
         self.assertEqual(429, callback.error.response.status)
 
+    def _wait_for_requests(self, count, timeout=5.0):
+        """Poll httpretty until at least ``count`` requests are recorded."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if len(httpretty.httpretty.latest_requests) >= count:
+                return
+            time.sleep(0.05)
+        self.fail("Timed out waiting for %s HTTP write(s); got %s" % (
+            count, len(httpretty.httpretty.latest_requests)))
+
+    def test_flush_partial_batch(self):
+        """flush() forces a write of buffered points below batch_size."""
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
+
+        # batch_size=2: a single point must stay buffered until flush
+        self._write_client.write("my-bucket", "my-org",
+                                 "h2o_feet,location=coyote_creek level\\ water_level=1 1")
+
+        time.sleep(0.3)
+        self.assertEqual(0, len(httpretty.httpretty.latest_requests))
+
+        self._write_client.flush()
+        self._wait_for_requests(1)
+
+        self.assertEqual(1, len(httpretty.httpretty.latest_requests))
+        self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=1 1",
+                         httpretty.httpretty.latest_requests[0].parsed_body)
+
+    def test_flush_allows_reuse(self):
+        """WriteApi remains usable after flush() — unlike close()."""
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
+
+        self._write_client.write("my-bucket", "my-org",
+                                 "h2o_feet,location=coyote_creek level\\ water_level=1 1")
+        self._write_client.flush()
+        self._wait_for_requests(1)
+
+        self._write_client.write("my-bucket", "my-org",
+                                 "h2o_feet,location=coyote_creek level\\ water_level=2 2")
+        self._write_client.flush()
+        self._wait_for_requests(2)
+
+        self.assertEqual(2, len(httpretty.httpretty.latest_requests))
+        self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=1 1",
+                         httpretty.httpretty.latest_requests[0].parsed_body)
+        self.assertEqual("h2o_feet,location=coyote_creek level\\ water_level=2 2",
+                         httpretty.httpretty.latest_requests[1].parsed_body)
+
+    def test_flush_empty_is_noop(self):
+        """flush() with an empty buffer does not send an HTTP request."""
+        httpretty.register_uri(httpretty.POST, uri="http://localhost/api/v2/write", status=204)
+
+        self._write_client.flush()
+        time.sleep(0.3)
+        self.assertEqual(0, len(httpretty.httpretty.latest_requests))
+
+    def test_flush_synchronous_is_noop(self):
+        """flush() is a no-op for non-batching write types."""
+        from influxdb_client.client.write_api import SYNCHRONOUS
+
+        self._write_client.close()
+        self._write_client = WriteApi(influxdb_client=self.influxdb_client,
+                                      write_options=SYNCHRONOUS)
+        # Must not raise
+        self._write_client.flush()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Proposed Changes

`WriteApi.flush()` was documented as a stable API but implemented as a `TODO` / `pass` no-op ([#697](https://github.com/influxdata/influxdb-client-python/issues/697)).

This implements `flush()` for **batching** mode by adding a flush boundary subject that forces the current batch window to close and send pending points over HTTP — the same approach used by the C# and Java client batch writers.

### Behavior
- **Forces** immediate write of any buffered data (does not wait for `batch_size` or `flush_interval`)
- **Does not dispose** the write pipeline — `WriteApi` remains usable after `flush()` (unlike `close()`)
- **No-op** for synchronous / asynchronous write types

### Implementation notes
- Pipeline uses `ops.publish` + `ops.window(rx.merge(time/count windows, flush_subject))`, mirroring [C# WriteApi](https://github.com/influxdata/influxdb-client-csharp/blob/master/Client/WriteApi.cs) / Java `FlowableBufferTimedFlushable`
- Empty flushes do not send HTTP requests (existing `batch.size > 0` filter)

Fixes #697

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `pytest tests/test_WriteApiBatching.py` completes successfully (new flush tests + existing batching tests)
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)

## Tests

```bash
pytest tests/test_WriteApiBatching.py -v --timeout=60
```

New coverage:
- `test_flush_partial_batch` — single point under `batch_size` is written on `flush()`
- `test_flush_allows_reuse` — further writes work after `flush()`
- `test_flush_empty_is_noop` — empty buffer does not HTTP
- `test_flush_synchronous_is_noop` — sync mode does not raise

## AI disclosure

AI assistance was used to locate the incomplete `flush()` stub, compare C#/Java batch-writer flush designs, draft the Rx boundary-window change, and write unit tests. The change was reviewed, kept scoped to the batching pipeline + tests + changelog, and verified with the batching unit tests above.

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.