### PR TITLE
docs: in CHANGELOG.md Replace Bug Fix URLS pointing to issues with UR…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ### Bug Fixes
 
 1. [#706](https://github.com/influxdata/influxdb-client-python/pull/706): Use logger instead logging.
-1. [#540](https://github.com/influxdata/influxdb-client-python/issues/540): Replace invalid tuple type annotations `(str, str, str)` with `Tuple[str, str, str]` in batching callbacks, examples and docs.
-1. [#686](https://github.com/influxdata/influxdb-client-python/issues/686): Stop `default_tags` from one client leaking into other clients' `WriteApi` (shared mutable default `PointSettings`).
-1. [#697](https://github.com/influxdata/influxdb-client-python/issues/697): Implement `WriteApi.flush()` to force pending batch writes without disposing the API (mirrors C#/Java batch writer).
-1. [#681](https://github.com/influxdata/influxdb-client-python/issues/681): Accept numeric zero for `RangeThreshold.min`/`max` and greater/lesser `value` (identity checks vs `None`, not truthiness); cover create-check serialization.
+1. [#710](https://github.com/influxdata/influxdb-client-python/pull/710): Stop `default_tags` from one client leaking into other clients' `WriteApi` (shared mutable default `PointSettings`).
+1. [#713](https://github.com/influxdata/influxdb-client-python/pull/713): Replace invalid tuple type annotations `(str, str, str)` with `Tuple[str, str, str]` in batching callbacks, examples and docs.
+1. [#714](https://github.com/influxdata/influxdb-client-python/pull/714): Implement `WriteApi.flush()` to force pending batch writes without disposing the API (mirrors C#/Java batch writer).
+1. [#715](https://github.com/influxdata/influxdb-client-python/pull/715): Accept numeric zero for `RangeThreshold.min`/`max` and greater/lesser `value` (identity checks vs `None`, not truthiness); cover create-check serialization.
 
 ## 1.50.0 [2026-01-23]
 


### PR DESCRIPTION
## Proposed Changes

In some recent PR merges, the CHANGELOG contained URLs to original issues instead of URLs to the PRs that resolved them.  These URLs have been fixed.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- ~[ ] A test has been added if appropriate~ N.A.
- [x] `pytest tests` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
